### PR TITLE
Add initial schema definition

### DIFF
--- a/chronogram_pipeline/config/schema_definition.yaml
+++ b/chronogram_pipeline/config/schema_definition.yaml
@@ -1,0 +1,39 @@
+---
+fields:
+  - name: id_inject
+    type: string
+    required: true
+  - name: horodatage
+    type: string
+    required: false
+  - name: description
+    type: string
+    required: false
+  - name: emetteur
+    type: string
+    required: false
+  - name: destinataire
+    type: string
+    required: false
+  - name: type_inject
+    type: string
+    required: true
+    values: ["Critique", "Important", "Secondaire"]
+  - name: modalite
+    type: string
+    required: false
+  - name: phase_exercice
+    type: string
+    required: false
+  - name: observations
+    type: string
+    required: false
+  - name: etablissement_nom
+    type: string
+    required: false
+  - name: etablissement_type
+    type: string
+    required: false
+
+database:
+  engine: sqlite


### PR DESCRIPTION
## Summary
- define database schema in `schema_definition.yaml`

## Testing
- `yamllint config/schema_definition.yaml`
- `python - <<'PY'
import yaml, sys
with open('config/schema_definition.yaml', 'r') as f:
    schema = yaml.safe_load(f)
assert 'fields' in schema
assert isinstance(schema['fields'], list)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688a145b9ee483279dad5b8603d2288f