### PR TITLE
Add basic Python dependencies

### DIFF
--- a/chronogram_pipeline/requirements.txt
+++ b/chronogram_pipeline/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=2.0.0
+openpyxl>=3.1.2
+openai>=1.10.0
+python-dotenv>=1.0.0
+pyyaml>=6.0


### PR DESCRIPTION
## Summary
- add Python dependencies for the chronogram pipeline

## Testing
- `python -m venv venv`
- `pip install -r chronogram_pipeline/requirements.txt`
- `python - <<'PY'
import pandas, openpyxl, openai, dotenv, yaml
print('imports successful')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688a149d852083279657805e9ed2d36f