### PR TITLE
Configure JSON logger

### DIFF
--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -1,8 +1,8 @@
-import logging
+from .logger import get_logger
 import sqlite3
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 CHRONO_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS Chronogrammes (

--- a/chronogram_pipeline/src/init_db.py
+++ b/chronogram_pipeline/src/init_db.py
@@ -1,11 +1,10 @@
 """Script to initialise SQLite databases for the chronogram pipeline."""
-import logging
 from pathlib import Path
 
 from db_utils import init_databases
+from .logger import get_logger
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def main() -> None:

--- a/chronogram_pipeline/src/logger.py
+++ b/chronogram_pipeline/src/logger.py
@@ -1,0 +1,69 @@
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+
+def _build_formatter():
+    """Return a JSON formatter for log records."""
+    try:
+        from pythonjsonlogger import jsonlogger
+
+        class CustomJsonFormatter(jsonlogger.JsonFormatter):
+            def add_fields(self, log_record, record, message_dict):
+                super().add_fields(log_record, record, message_dict)
+                # Rename default fields
+                log_record['timestamp'] = log_record.pop('asctime')
+                log_record['level'] = log_record.pop('levelname')
+                log_record['module'] = record.module
+                log_record['message'] = record.getMessage()
+                # Remove redundant fields
+                for key in ['name', 'funcName']:  # keep module only
+                    log_record.pop(key, None)
+
+        fmt = '%(asctime)s %(levelname)s %(module)s %(message)s'
+        return CustomJsonFormatter(fmt=fmt, datefmt='%Y-%m-%dT%H:%M:%S')
+    except Exception:
+
+        class SimpleJsonFormatter(logging.Formatter):
+            def format(self, record: logging.LogRecord) -> str:
+                data = {
+                    'timestamp': datetime.utcfromtimestamp(record.created).strftime('%Y-%m-%dT%H:%M:%S'),
+                    'level': record.levelname,
+                    'module': record.module,
+                    'message': record.getMessage(),
+                }
+                return json.dumps(data)
+
+        return SimpleJsonFormatter()
+
+
+def get_logger(name: str = "chronologger") -> logging.Logger:
+    """Return a configured logger writing JSON logs to console and file."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.DEBUG)
+
+    base_dir = Path(__file__).resolve().parents[1]
+    log_dir = Path(os.getenv("CHRONO_LOG_DIR", base_dir / "data/control"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    log_file = log_dir / f"run_{timestamp}.log"
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+
+    formatter = _build_formatter()
+    stream_handler.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+
+    logger.addHandler(stream_handler)
+    logger.addHandler(file_handler)
+    logger.propagate = False
+    return logger

--- a/chronogram_pipeline/tests/test_logger.py
+++ b/chronogram_pipeline/tests/test_logger.py
@@ -1,0 +1,25 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+# allow imports from project root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.logger import get_logger
+
+
+def test_get_logger_creates_json_file(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHRONO_LOG_DIR", str(log_dir))
+    logger = get_logger("test_logger")
+    logger.info("message test")
+    for h in logger.handlers:
+        if hasattr(h, "flush"):
+            h.flush()
+    files = list(log_dir.glob("run_*.log"))
+    assert len(files) == 1
+    content = files[0].read_text().strip()
+    data = json.loads(content)
+    assert data["message"] == "message test"
+    assert data["level"] == "INFO"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl>=3.1.2
 openai>=1.10.0
 python-dotenv>=1.0.0
 pyyaml>=6.0
+python-json-logger>=2.0


### PR DESCRIPTION
## Summary
- add python-json-logger dependency
- implement `get_logger` in `logger.py`
- use new logger in `db_utils` and `init_db`
- test logger output

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a35b1937083279c05d0c5edb6aad6