### PR TITLE
Implement detect_main_sheet

### DIFF
--- a/chronogram_pipeline/src/excel_parser.py
+++ b/chronogram_pipeline/src/excel_parser.py
@@ -1,0 +1,120 @@
+import logging
+from pathlib import Path
+from typing import Union
+
+from openpyxl import load_workbook, Workbook
+
+logger = logging.getLogger(__name__)
+
+KEYWORDS = {"chronogramme", "exercice"}
+
+
+def _count_non_empty(ws) -> int:
+    """Return number of non-empty cells in worksheet."""
+    count = 0
+    for row in ws.iter_rows(values_only=True):
+        for cell in row:
+            if cell not in (None, ""):
+                count += 1
+    return count
+
+
+def _contains_keyword(ws) -> bool:
+    title = ws.title.lower()
+    if any(k in title for k in KEYWORDS):
+        return True
+    # check first few cells
+    for row in ws.iter_rows(min_row=1, max_row=5, max_col=5, values_only=True):
+        for cell in row:
+            if isinstance(cell, str) and any(k in cell.lower() for k in KEYWORDS):
+                return True
+    return False
+
+
+def _ai_select_sheet(candidates):
+    """Use OpenAI to select sheet from candidates. Return worksheet."""
+    try:
+        import openai
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("openai not available") from exc
+
+    if not openai.api_key:
+        raise RuntimeError("OPENAI_API_KEY not configured")
+
+    prompt = [
+        {
+            "role": "system",
+            "content": (
+                "Parmi les feuilles suivantes d'un classeur Excel, laquelle contient"
+                " probablement un chronogramme d'exercice ? Réponds uniquement par le"
+                " nom de la feuille."
+            ),
+        }
+    ]
+
+    for ws, _kw, _count in candidates:
+        sample_lines = []
+        for row in ws.iter_rows(min_row=1, max_row=5, max_col=5, values_only=True):
+            sample_lines.append(
+                "\t".join("" if c is None else str(c) for c in row)
+            )
+        sample = "\n".join(sample_lines)
+        prompt.append({"role": "user", "content": f"Feuille: {ws.title}\n{sample}"})
+
+    response = openai.ChatCompletion.create(model="gpt-4-turbo", messages=prompt)
+    name = response.choices[0].message.content.strip()
+    for ws, _kw, _count in candidates:
+        if ws.title.lower() == name.lower():
+            return ws
+    # if not matched, return first
+    return candidates[0][0]
+
+
+def detect_main_sheet(workbook: Union[str, Path, Workbook]):
+    """Detect the worksheet containing the main chronogram table."""
+    if isinstance(workbook, (str, Path)):
+        wb = load_workbook(workbook, data_only=True)
+    elif isinstance(workbook, Workbook):
+        wb = workbook
+    else:
+        raise TypeError("workbook must be path or Workbook")
+
+    sheet_info = []
+    for ws in wb.worksheets:
+        non_empty = _count_non_empty(ws)
+        total = ws.max_row * ws.max_column if ws.max_row and ws.max_column else 0
+        density = non_empty / total if total else 0
+        has_kw = _contains_keyword(ws)
+        logger.debug(
+            "Sheet %s: %d non-empty cells, density %.3f, keyword %s",
+            ws.title,
+            non_empty,
+            density,
+            has_kw,
+        )
+        sheet_info.append((ws, has_kw, non_empty, density))
+
+    # filter by keyword if any
+    sheets_with_kw = [info for info in sheet_info if info[1]]
+    candidates = sheets_with_kw if sheets_with_kw else sheet_info
+
+    # pick with highest non-empty cell count
+    max_count = max(info[2] for info in candidates) if candidates else 0
+    top_candidates = [info for info in candidates if info[2] == max_count]
+
+    if len(top_candidates) == 1:
+        ws, has_kw, count, _ = top_candidates[0]
+        logger.info("Selected sheet '%s' (%d non-empty cells)", ws.title, count)
+        return ws.title
+
+    # multiple candidates -> try AI
+    try:
+        ws = _ai_select_sheet(top_candidates)
+        logger.info("Selected sheet '%s' via AI", ws.title)
+        return ws.title
+    except Exception as exc:  # pragma: no cover - fallback
+        ws, has_kw, count, _ = top_candidates[0]
+        logger.warning(
+            "AI selection failed (%s). Defaulting to sheet '%s'", exc, ws.title
+        )
+        return ws.title

--- a/chronogram_pipeline/tests/test_excel_parser.py
+++ b/chronogram_pipeline/tests/test_excel_parser.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import openpyxl
+
+# allow imports from project root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.excel_parser import detect_main_sheet
+
+
+def make_workbook():
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Data"
+    for i in range(3):
+        ws1.cell(row=i + 1, column=1, value=i)
+    ws2 = wb.create_sheet("Chronogramme")
+    ws2.cell(row=1, column=1, value="header")
+    wb.create_sheet("Empty")
+    return wb
+
+
+def test_detect_main_sheet_prefers_keyword():
+    wb = make_workbook()
+    assert detect_main_sheet(wb) == "Chronogramme"
+
+
+def test_detect_main_sheet_highest_density():
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Sheet1"
+    for i in range(2):
+        for j in range(2):
+            ws1.cell(row=i + 1, column=j + 1, value=1)
+    ws2 = wb.create_sheet("Sheet2")
+    for i in range(3):
+        for j in range(3):
+            if i != 2:
+                ws2.cell(row=i + 1, column=j + 1, value=1)
+    assert detect_main_sheet(wb) == "Sheet2"
+
+
+def test_detect_main_sheet_tie_returns_first():
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "A"
+    ws1.cell(row=1, column=1, value=1)
+    ws2 = wb.create_sheet("B")
+    ws2.cell(row=1, column=1, value=1)
+    assert detect_main_sheet(wb) == "A"


### PR DESCRIPTION
## Summary
- implement Excel sheet detection logic
- add helper functions for keyword detection and AI fallback
- include tests for the new `detect_main_sheet` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a35e2f5048327bf7b9195c25f366c