### PR TITLE
Add header mapping preparation utility

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -1,0 +1,16 @@
+from .db_utils import create_connection, init_databases
+from .mapping_utils import (
+    detect_main_sheet,
+    find_data_table,
+    extract_headers,
+    update_mapping_headers,
+)
+
+__all__ = [
+    "create_connection",
+    "init_databases",
+    "detect_main_sheet",
+    "find_data_table",
+    "extract_headers",
+    "update_mapping_headers",
+]

--- a/chronogram_pipeline/src/mapping_utils.py
+++ b/chronogram_pipeline/src/mapping_utils.py
@@ -1,0 +1,88 @@
+import logging
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import openpyxl
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def detect_main_sheet(workbook_path: Path) -> openpyxl.worksheet.worksheet.Worksheet:
+    """Return the worksheet with the highest number of non-empty cells."""
+    wb = openpyxl.load_workbook(workbook_path, data_only=True)
+    best_sheet = wb.worksheets[0]
+    max_count = -1
+    for ws in wb.worksheets:
+        count = sum(
+            1
+            for row in ws.iter_rows(values_only=True)
+            for cell in row
+            if cell not in (None, "")
+        )
+        if count > max_count:
+            best_sheet = ws
+            max_count = count
+    logger.info("Selected sheet '%s' with %d cells from %s", best_sheet.title, max_count, workbook_path)
+    return best_sheet
+
+
+def find_data_table(sheet: openpyxl.worksheet.worksheet.Worksheet) -> Tuple[int, int, int]:
+    """Return header row index and start/end columns of the data table."""
+    for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+        values = [cell for cell in row if cell not in (None, "")]
+        if len(values) >= 3:
+            first_col = next(i for i, c in enumerate(row, start=1) if c not in (None, ""))
+            last_col = len(row) - next(i for i, c in enumerate(reversed(row), start=1) if c not in (None, "")) + 1
+            logger.info("Header row detected at line %d", idx)
+            return idx, first_col, last_col
+    raise ValueError("No header row found")
+
+
+def extract_headers(sheet: openpyxl.worksheet.worksheet.Worksheet, header_row: int, first_col: int, last_col: int) -> List[str]:
+    cells = sheet.iter_rows(min_row=header_row, max_row=header_row, min_col=first_col, max_col=last_col, values_only=True)
+    headers = []
+    for row in cells:
+        for value in row:
+            if value not in (None, ""):
+                headers.append(str(value).strip())
+    return headers
+
+
+def update_mapping_headers(input_dir: Path, mapping_csv: Path, max_files: int = 3) -> Tuple[int, int]:
+    """Update mapping CSV with headers extracted from Excel files.
+
+    Returns (total_headers_found, new_headers_added).
+    """
+    excel_files = [p for p in input_dir.iterdir() if p.suffix.lower() in {".xlsx", ".xls"}]
+    excel_files.sort()
+    if not excel_files:
+        logger.warning("No Excel files found in %s", input_dir)
+        return 0, 0
+    excel_files = excel_files[:max_files]
+
+    all_headers: List[str] = []
+    for file in excel_files:
+        sheet = detect_main_sheet(file)
+        header_row, first_col, last_col = find_data_table(sheet)
+        headers = extract_headers(sheet, header_row, first_col, last_col)
+        logger.info("%s -> %d headers", file, len(headers))
+        all_headers.extend(headers)
+
+    total_headers = len(all_headers)
+    headers_set = {h for h in all_headers if h}
+
+    if mapping_csv.exists() and mapping_csv.stat().st_size > 0:
+        df = pd.read_csv(mapping_csv)
+    else:
+        df = pd.DataFrame(columns=["En-tête original", "En-tête standard"])
+
+    existing = set(df["En-tête original"].astype(str))
+    new_entries = [h for h in headers_set if h not in existing]
+    for header in new_entries:
+        df.loc[len(df)] = [header, ""]
+
+    if new_entries:
+        df.to_csv(mapping_csv, index=False)
+    logger.info("%d headers extracted, %d new entries added", total_headers, len(new_entries))
+    return total_headers, len(new_entries)

--- a/chronogram_pipeline/tests/test_mapping_utils.py
+++ b/chronogram_pipeline/tests/test_mapping_utils.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import shutil
+import pandas as pd
+
+from src.mapping_utils import update_mapping_headers
+
+
+def test_update_mapping_headers(tmp_path):
+    source_dir = Path(__file__).resolve().parents[1] / "data" / "inputs"
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    for name in ["Chronogramme.xlsx", "Chronogramme sur mesure.xlsx"]:
+        shutil.copy(source_dir / name, inputs_dir / name)
+    mapping_csv = tmp_path / "mapping_headers.csv"
+
+    # prepopulate with one known header
+    df = pd.DataFrame([["L", ""]], columns=["En-tête original", "En-tête standard"])
+    df.to_csv(mapping_csv, index=False)
+
+    total, new_added = update_mapping_headers(inputs_dir, mapping_csv, max_files=2)
+
+    result = pd.read_csv(mapping_csv)
+    headers = set(result["En-tête original"].tolist())
+
+    expected_headers = {
+        "L",
+        "Nature de l'inject",
+        "Condition",
+        "ID",
+        "Statut inject",
+        "Emetteur",
+        "Destinataire",
+        "Descriptif",
+        "Corps",
+        "Modalité",
+        "Réactions attendues",
+        "Tango",
+        "N°",
+        "Timing",
+        "Type",
+        "Saturant",
+        "Nature",
+        "Emmeteur",
+        "Récepteur",
+        "Description",
+        "Actions attendues",
+    }
+
+    assert expected_headers.issubset(headers)
+    assert new_added == len(expected_headers) - 1
+    assert total >= len(expected_headers)


### PR DESCRIPTION
## Summary
- implement `mapping_utils` module for scanning Excel headers
- expose new utilities via `src/__init__`
- test updating mapping headers from example files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a36446bf083278eafb89aeadf5932