### PR TITLE
Implement form handling with DB insertion

### DIFF
--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -1,8 +1,13 @@
 from .logger import get_logger
 import sqlite3
+from datetime import datetime
 from pathlib import Path
+from typing import Dict, Any
 
 logger = get_logger(__name__)
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_DB = BASE_DIR / "output/databases/chronogrammes.db"
 
 CHRONO_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS Chronogrammes (
@@ -64,3 +69,29 @@ def init_databases(chronogram_db: Path, injects_db: Path) -> None:
         with create_connection(injects_db) as inject_conn:
             init_tables(inject_conn)
     logger.info("Databases initialised: %s, %s", chronogram_db, injects_db)
+
+
+def insert_chronogram(record: Dict[str, Any], db_path: Path | None = None) -> int:
+    """Insert a chronogram record and return its generated ID."""
+    db_path = db_path or DEFAULT_DB
+    with create_connection(db_path) as conn:
+        init_tables(conn)
+        columns = [
+            "nom_chronogramme",
+            "date_exercice",
+            "lieu_exercice",
+            "etablissement_nom",
+            "etablissement_type",
+            "submitter",
+            "date_soumission",
+            "fichier_source",
+            "nb_injects",
+        ]
+        values = [record.get(col) for col in columns]
+        placeholders = ", ".join("?" for _ in columns)
+        sql = f"INSERT INTO Chronogrammes ({', '.join(columns)}) VALUES ({placeholders})"
+        cur = conn.execute(sql, values)
+        conn.commit()
+        chrono_id = int(cur.lastrowid)
+        logger.debug("Inserted chronogram with id %s", chrono_id)
+        return chrono_id

--- a/chronogram_pipeline/src/form_handler.py
+++ b/chronogram_pipeline/src/form_handler.py
@@ -1,0 +1,58 @@
+"""Handle user form submission and store chronogram metadata."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple, Dict, Any
+
+from .logger import get_logger
+from .db_utils import insert_chronogram, DEFAULT_DB, BASE_DIR
+
+logger = get_logger(__name__)
+
+INPUTS_DIR = BASE_DIR / "data/inputs"
+
+
+def _sanitize(name: str) -> str:
+    """Return a filesystem safe version of ``name``."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("._-")
+    return cleaned or "chronogramme"
+
+
+def handle_form_submission(form_data: Dict[str, Any]) -> Tuple[int, str]:
+    """Save uploaded Excel file and insert metadata.
+
+    Parameters
+    ----------
+    form_data : dict
+        Dictionary containing form fields and ``file_path`` key pointing to the
+        temporary uploaded Excel file.
+
+    Returns
+    -------
+    tuple
+        ``(id_chronogramme, final_path)`` where ``final_path`` is the path of
+        the stored Excel file.
+    """
+
+    src_path = Path(form_data["file_path"])
+    INPUTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    base = _sanitize(str(form_data.get("nom_chronogramme", "chronogramme")))
+    dest_name = f"{base}_{timestamp}{src_path.suffix}"
+    dest_path = INPUTS_DIR / dest_name
+
+    logger.info("Saving uploaded file to %s", dest_path)
+    shutil.move(str(src_path), dest_path)
+
+    form_data["fichier_source"] = str(dest_path)
+
+    chrono_id = insert_chronogram(form_data, db_path=DEFAULT_DB)
+    logger.info("Inserted chronogram %s with id %s", form_data.get("nom_chronogramme"), chrono_id)
+
+    return chrono_id, str(dest_path)
+

--- a/chronogram_pipeline/tests/test_form_handler.py
+++ b/chronogram_pipeline/tests/test_form_handler.py
@@ -1,0 +1,41 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src import db_utils
+from src.form_handler import handle_form_submission
+
+
+def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
+    db_path = tmp_path / "chronogrammes.db"
+    monkeypatch.setattr(db_utils, "DEFAULT_DB", db_path)
+    monkeypatch.setattr("src.form_handler.DEFAULT_DB", db_path)
+    monkeypatch.setattr("src.form_handler.INPUTS_DIR", tmp_path / "inputs")
+
+    conn = db_utils.create_connection(db_path)
+    db_utils.init_tables(conn)
+    conn.close()
+
+    src_file = tmp_path / "upload.xlsx"
+    src_file.write_text("data")
+
+    form_data = {
+        "nom_chronogramme": "Test",
+        "file_path": str(src_file),
+    }
+
+    chrono_id, dest_path = handle_form_submission(form_data)
+
+    assert not src_file.exists()
+    assert Path(dest_path).exists()
+    assert chrono_id == 1
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT nom_chronogramme, fichier_source FROM Chronogrammes WHERE id_chronogramme=?",
+            (chrono_id,),
+        )
+        row = cur.fetchone()
+    assert row == ("Test", dest_path)


### PR DESCRIPTION
## Summary
- add file upload handling in `form_handler.py`
- support DB insertion of chronogram records in `db_utils.insert_chronogram`
- test that uploads are moved and metadata inserted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a37f6399c8327ad276658d0708341