### PR TITLE
Switch parser tests to use real Excel files

### DIFF
--- a/chronogram_pipeline/tests/test_excel_parser.py
+++ b/chronogram_pipeline/tests/test_excel_parser.py
@@ -8,44 +8,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.excel_parser import detect_main_sheet
 
-
-def make_workbook():
-    wb = openpyxl.Workbook()
-    ws1 = wb.active
-    ws1.title = "Data"
-    for i in range(3):
-        ws1.cell(row=i + 1, column=1, value=i)
-    ws2 = wb.create_sheet("Chronogramme")
-    ws2.cell(row=1, column=1, value="header")
-    wb.create_sheet("Empty")
-    return wb
+INPUTS_DIR = Path(__file__).resolve().parents[1] / "data" / "inputs"
 
 
 def test_detect_main_sheet_prefers_keyword():
-    wb = make_workbook()
-    assert detect_main_sheet(wb) == "Chronogramme"
+    path = INPUTS_DIR / "test bonne feuille et trcabilité feuille.xlsx"
+    assert detect_main_sheet(path) == "Chronogramme"
 
 
 def test_detect_main_sheet_highest_density():
-    wb = openpyxl.Workbook()
-    ws1 = wb.active
-    ws1.title = "Sheet1"
-    for i in range(2):
-        for j in range(2):
-            ws1.cell(row=i + 1, column=j + 1, value=1)
-    ws2 = wb.create_sheet("Sheet2")
-    for i in range(3):
-        for j in range(3):
-            if i != 2:
-                ws2.cell(row=i + 1, column=j + 1, value=1)
-    assert detect_main_sheet(wb) == "Sheet2"
+    path = INPUTS_DIR / "Kit intermédiaire.xlsx"
+    assert detect_main_sheet(path) == "Chrono"
 
 
 def test_detect_main_sheet_tie_returns_first():
-    wb = openpyxl.Workbook()
-    ws1 = wb.active
-    ws1.title = "A"
-    ws1.cell(row=1, column=1, value=1)
-    ws2 = wb.create_sheet("B")
-    ws2.cell(row=1, column=1, value=1)
-    assert detect_main_sheet(wb) == "A"
+    path = INPUTS_DIR / "Chronogramme.xlsx"
+    wb = openpyxl.load_workbook(path)
+    wb.copy_worksheet(wb.active)
+    assert detect_main_sheet(wb) == "Chronogramme "


### PR DESCRIPTION
## Summary
- update tests for `detect_main_sheet` to rely on actual Excel samples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3ce7a19c83279ae5fb40551fb90a