### PR TITLE
Add header standardizer with Mistral fallback

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -5,6 +5,7 @@ from .mapping_utils import (
     extract_headers,
     update_mapping_headers,
 )
+from .standardizer import standardize_headers
 
 __all__ = [
     "create_connection",
@@ -13,4 +14,5 @@ __all__ = [
     "find_data_table",
     "extract_headers",
     "update_mapping_headers",
+    "standardize_headers",
 ]

--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -1,0 +1,127 @@
+"""Header standardization utilities with optional Mistral AI fallback."""
+
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Callable, Iterable, List, Mapping
+
+import pandas as pd
+import requests
+import yaml
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+# Type of the callback used to suggest a header
+SuggestFunc = Callable[[str, Iterable[str]], str]
+
+
+def _load_mapping(mapping_csv: Path) -> Mapping[str, str]:
+    if mapping_csv.exists() and mapping_csv.stat().st_size > 0:
+        df = pd.read_csv(mapping_csv)
+        return dict(zip(df.iloc[:, 0].astype(str), df.iloc[:, 1].astype(str)))
+    return {}
+
+
+def _save_mapping(mapping_csv: Path, mapping: Mapping[str, str]) -> None:
+    df = pd.DataFrame(list(mapping.items()), columns=["En-tête original", "En-tête standard"])
+    mapping_csv.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(mapping_csv, index=False)
+
+
+def _load_schema(schema_path: Path | None) -> List[str]:
+    if schema_path and schema_path.exists():
+        data = yaml.safe_load(schema_path.read_text())
+        fields = [f.get("name") for f in data.get("fields", [])]
+        return [str(f) for f in fields if f]
+    return []
+
+
+def _default_mistral_call(header: str, allowed: Iterable[str]) -> str:
+    api_key = os.getenv("MISTRAL_API_KEY")
+    if not api_key:
+        raise RuntimeError("MISTRAL_API_KEY not set")
+    prompt = (
+        "En-tête original: "
+        + header
+        + "\nChamps autorisés: "
+        + ", ".join(allowed)
+        + "\nPropose uniquement le nom du champ standard le plus pertinent."
+    )
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    payload = {
+        "model": "mistral-small",
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    resp = requests.post("https://api.mistral.ai/v1/chat/completions", headers=headers, json=payload, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"].strip()
+
+
+def standardize_headers(
+    headers_list: Iterable[str],
+    *,
+    mapping_csv: Path,
+    schema_path: Path | None = None,
+    prompts_dir: Path | None = None,
+    gpt_suggest_header: SuggestFunc | None = None,
+    file_name: str | None = None,
+    log_xlsx: Path | None = None,
+) -> List[str]:
+    """Return list of standardized headers using dictionary and optional AI."""
+    mapping = _load_mapping(mapping_csv)
+    allowed = _load_schema(schema_path)
+
+    prompts_dir = prompts_dir or Path("prompts")
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    new_mapping = False
+    result: List[str] = []
+    log_rows = []
+
+    suggest = gpt_suggest_header or _default_mistral_call
+
+    for header in headers_list:
+        header_str = "" if header is None else str(header).strip()
+        if not header_str:
+            result.append(header_str)
+            continue
+        if header_str in mapping and mapping[header_str]:
+            std = mapping[header_str]
+            method = "dict"
+        else:
+            prompt_text = (
+                f"En-tête original: {header_str}\n"
+                f"Champs autorisés: {', '.join(allowed)}\n"
+                "Instruction: proposer le champ standard le plus pertinent, et uniquement le nom."
+            )
+            safe_header = header_str.replace("/", "_").replace(" ", "_")
+            base = file_name or "file"
+            prompt_file = prompts_dir / f"{base}_header_{safe_header}.txt"
+            prompt_file.write_text(prompt_text, encoding="utf-8")
+
+            std = suggest(header_str, allowed)
+            mapping[header_str] = std
+            new_mapping = True
+            method = "IA"
+        log_rows.append((header_str, std, method))
+        result.append(std)
+
+    if new_mapping:
+        _save_mapping(mapping_csv, mapping)
+
+    if log_xlsx:
+        if log_xlsx.exists():
+            df_log = pd.read_excel(log_xlsx)
+        else:
+            df_log = pd.DataFrame(columns=["En-tête original", "En-tête standard", "Méthode"])
+        for row in log_rows:
+            df_log.loc[len(df_log)] = row
+        df_log.to_excel(log_xlsx, index=False)
+
+    for orig, std, method in log_rows:
+        logger.info("Header '%s' -> '%s' via %s", orig, std, method)
+
+    return result
+

--- a/chronogram_pipeline/tests/test_standardizer_headers.py
+++ b/chronogram_pipeline/tests/test_standardizer_headers.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.standardizer import standardize_headers
+
+
+def test_standardize_headers_uses_dictionary_first(tmp_path):
+    mapping_csv = tmp_path / "mapping_headers.csv"
+    mapping_csv.write_text("En-tête original,En-tête standard\nDescriptif,Contenu\n")
+
+    schema_yaml = tmp_path / "schema.yaml"
+    schema_yaml.write_text("fields:\n  - name: Contenu\n  - name: Destinataire\n  - name: Modalité\n")
+
+    prompts_dir = tmp_path / "prompts"
+
+    calls = []
+
+    def fake_gpt(header, allowed):
+        calls.append(header)
+        return "Destinataire"
+
+    headers = ["Descriptif", "Destinataires"]
+
+    out = standardize_headers(
+        headers,
+        mapping_csv=mapping_csv,
+        schema_path=schema_yaml,
+        prompts_dir=prompts_dir,
+        gpt_suggest_header=fake_gpt,
+        file_name="testfile",
+        log_xlsx=tmp_path / "log.xlsx",
+    )
+
+    assert out == ["Contenu", "Destinataire"]
+    assert calls == ["Destinataires"]
+
+    df = pd.read_csv(mapping_csv)
+    assert "Destinataires" in df["En-tête original"].values
+    # prompt saved
+    assert (prompts_dir / "testfile_header_Destinataires.txt").exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openai>=1.10.0
 python-dotenv>=1.0.0
 pyyaml>=6.0
 python-json-logger>=2.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- implement `standardize_headers` with optional Mistral API call for unknown headers
- expose `standardize_headers` via package `__all__`
- add `requests` dependency
- test header standardization behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b40bf64388327b48fedd91c04789d