### PR TITLE
Implement rule-based header standardization

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -5,7 +5,7 @@ from .mapping_utils import (
     extract_headers,
     update_mapping_headers,
 )
-from .standardizer import standardize_headers
+from .standardizer import standardize_headers, standardize_headers_rules
 
 __all__ = [
     "create_connection",
@@ -15,4 +15,5 @@ __all__ = [
     "extract_headers",
     "update_mapping_headers",
     "standardize_headers",
+    "standardize_headers_rules",
 ]

--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from typing import Callable, Iterable, List, Mapping
+from typing import Callable, Iterable, List, Mapping, Dict
 
 import pandas as pd
 import requests
 import yaml
 
 from .logger import get_logger
+from .mapping_utils import normalize_text
 
 logger = get_logger(__name__)
 
@@ -22,6 +23,17 @@ def _load_mapping(mapping_csv: Path) -> Mapping[str, str]:
         df = pd.read_csv(mapping_csv)
         return dict(zip(df.iloc[:, 0].astype(str), df.iloc[:, 1].astype(str)))
     return {}
+
+
+def _load_mapping_normalized(mapping_csv: Path) -> Dict[str, str]:
+    """Load mapping with normalized keys for rule-based matching."""
+    mapping: Dict[str, str] = {}
+    if mapping_csv.exists() and mapping_csv.stat().st_size > 0:
+        df = pd.read_csv(mapping_csv)
+        for _, row in df.iterrows():
+            orig = normalize_text(str(row[0]))
+            mapping[orig] = str(row[1])
+    return mapping
 
 
 def _save_mapping(mapping_csv: Path, mapping: Mapping[str, str]) -> None:
@@ -58,6 +70,44 @@ def _default_mistral_call(header: str, allowed: Iterable[str]) -> str:
     resp.raise_for_status()
     data = resp.json()
     return data["choices"][0]["message"]["content"].strip()
+
+
+def standardize_headers_rules(
+    headers_list: Iterable[str],
+    *,
+    mapping_csv: Path,
+    log_xlsx: Path | None = None,
+) -> List[str]:
+    """Standardize headers using only local dictionary rules."""
+    mapping = _load_mapping_normalized(mapping_csv)
+    result: List[str] = []
+    log_rows = []
+
+    for header in headers_list:
+        header_str = "" if header is None else str(header).strip()
+        if not header_str:
+            result.append(header_str)
+            continue
+        norm = normalize_text(header_str)
+        std = mapping.get(norm, "")
+        log_rows.append((header_str, std, "règle"))
+        result.append(std)
+
+    if log_xlsx:
+        if log_xlsx.exists():
+            df_log = pd.read_excel(log_xlsx)
+        else:
+            df_log = pd.DataFrame(
+                columns=["En-tête original", "En-tête standard", "Méthode"]
+            )
+        for row in log_rows:
+            df_log.loc[len(df_log)] = row
+        df_log.to_excel(log_xlsx, index=False)
+
+    for orig, std, method in log_rows:
+        logger.info("Header '%s' -> '%s' via %s", orig, std, method)
+
+    return result
 
 
 def standardize_headers(

--- a/chronogram_pipeline/tests/test_standardizer_rules.py
+++ b/chronogram_pipeline/tests/test_standardizer_rules.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.standardizer import standardize_headers_rules
+
+
+def test_standardize_headers_rules(tmp_path):
+    mapping_csv = tmp_path / "mapping_headers.csv"
+    mapping_csv.write_text(
+        "En-tete original,En-tete standard\nDescriptif,Contenu\nDestinataires,Destinataire\n"
+    )
+
+    log_xlsx = tmp_path / "log.xlsx"
+    headers = ["Descriptif", "destinataires", "Inconnu"]
+
+    out = standardize_headers_rules(headers, mapping_csv=mapping_csv, log_xlsx=log_xlsx)
+
+    assert out == ["Contenu", "Destinataire", ""]
+
+    df = pd.read_excel(log_xlsx)
+    assert df.shape[0] == 3
+    assert (df["Méthode"] == "règle").all()


### PR DESCRIPTION
## Summary
- add rule-based header mapping that works without AI
- export new helper in `__init__`
- test rule-based header standardization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5cae3aa483279ca90198e2a53ebe