### PR TITLE
Add pipeline logger

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -6,6 +6,7 @@ from .mapping_utils import (
     update_mapping_headers,
 )
 from .standardizer import standardize_headers
+from .pipeline_logger import PipelineLogger
 
 __all__ = [
     "create_connection",
@@ -15,4 +16,5 @@ __all__ = [
     "extract_headers",
     "update_mapping_headers",
     "standardize_headers",
+    "PipelineLogger",
 ]

--- a/chronogram_pipeline/src/pipeline_logger.py
+++ b/chronogram_pipeline/src/pipeline_logger.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Any, Optional
+
+from .logger import get_logger
+
+@dataclass
+class StepMetrics:
+    name: str
+    start: datetime = field(default_factory=datetime.now)
+    end: Optional[datetime] = None
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+    def stop(self) -> None:
+        self.end = datetime.now()
+
+    @property
+    def duration(self) -> float:
+        if not self.end:
+            return 0.0
+        return (self.end - self.start).total_seconds()
+
+
+class _StepContext:
+    def __init__(self, pipeline_logger: "PipelineLogger", name: str):
+        self.pipeline_logger = pipeline_logger
+        self.step = StepMetrics(name)
+
+    def __enter__(self) -> Dict[str, Any]:
+        self.pipeline_logger.logger.info(
+            f"START_{self.step.name}",
+            extra={"event": "STEP_START", "step": self.step.name},
+        )
+        return self.step.metrics
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.step.stop()
+        data = {
+            "event": "STEP_END",
+            "step": self.step.name,
+            "duration": self.step.duration,
+            **self.step.metrics,
+        }
+        if exc_type is not None:
+            self.pipeline_logger.success = False
+            data["error"] = str(exc)
+            self.pipeline_logger.logger.error(f"ERROR_{self.step.name}", extra=data)
+        else:
+            self.pipeline_logger.logger.info(f"END_{self.step.name}", extra=data)
+        self.pipeline_logger.steps.append(self.step)
+
+
+class PipelineLogger:
+    """Helper to log pipeline steps with metrics and summary."""
+
+    def __init__(self, name: str = "chronopipeline") -> None:
+        self.logger = get_logger(name)
+        self.start = datetime.now()
+        self.steps: List[StepMetrics] = []
+        self.success = True
+
+    def step(self, name: str) -> _StepContext:
+        return _StepContext(self, name)
+
+    def summary(self) -> None:
+        total = (datetime.now() - self.start).total_seconds()
+        summary_steps = []
+        for st in self.steps:
+            entry = {"name": st.name, "duration": st.duration}
+            entry.update(st.metrics)
+            summary_steps.append(entry)
+        self.logger.info(
+            "SUMMARY",
+            extra={
+                "event": "SUMMARY",
+                "status": "SUCCES" if self.success else "ECHEC",
+                "total_duration": total,
+                "steps": summary_steps,
+            },
+        )
+

--- a/chronogram_pipeline/tests/test_pipeline_logger.py
+++ b/chronogram_pipeline/tests/test_pipeline_logger.py
@@ -1,0 +1,25 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.pipeline_logger import PipelineLogger
+
+
+def test_pipeline_logger_records_steps(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHRONO_LOG_DIR", str(tmp_path))
+    plog = PipelineLogger("test_pipeline")
+
+    with plog.step("STEP1") as m:
+        m["lines"] = 10
+
+    plog.summary()
+
+    log_file = list(Path(tmp_path).glob("run_*.log"))[0]
+    lines = [json.loads(l) for l in log_file.read_text().splitlines()]
+    events = [l["event"] for l in lines]
+    assert "STEP_START" in events
+    assert "STEP_END" in events
+    assert lines[-1]["event"] == "SUMMARY"
+    assert lines[-1]["status"] == "SUCCES"


### PR DESCRIPTION
## Summary
- add a PipelineLogger helper to trace step metrics
- export PipelineLogger in package init
- test PipelineLogger behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5d4a8b7c8327a7835767a8165028