### PR TITLE
Fix pandas Series access warning

### DIFF
--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -40,8 +40,8 @@ def _load_mapping_normalized(mapping_csv: Path) -> Dict[str, str]:
     if mapping_csv.exists() and mapping_csv.stat().st_size > 0:
         df = pd.read_csv(mapping_csv)
         for _, row in df.iterrows():
-            orig = normalize_text(str(row[0]))
-            mapping[orig] = str(row[1])
+            orig = normalize_text(str(row.iloc[0]))
+            mapping[orig] = str(row.iloc[1])
     return mapping
 
 


### PR DESCRIPTION
## Summary
- fix Series numeric index access in `_load_mapping_normalized`
- no more FutureWarning when reading header mapping

## Testing
- `pytest chronogram_pipeline/tests/test_standardizer_rules.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b61cd00988327b152c124a7bfb1e9