### PR TITLE
Improve file upload handling

### DIFF
--- a/chronogram_pipeline/src/form_handler.py
+++ b/chronogram_pipeline/src/form_handler.py
@@ -22,8 +22,22 @@ def _sanitize(name: str) -> str:
     return cleaned or "chronogramme"
 
 
+def _format_component(value: str) -> str:
+    """Return cleaned and title-cased component for filename."""
+    cleaned = _sanitize(value)
+    parts = [p for p in cleaned.split("_") if p]
+    formatted = "_".join(part if part.isupper() else part.capitalize() for part in parts)
+    return formatted
+
+
 def handle_form_submission(form_data: Dict[str, Any]) -> Tuple[int, str]:
     """Save uploaded Excel file and insert metadata.
+
+    The uploaded Excel file is renamed using ``etablissement_nom``,
+    ``nom_chronogramme`` and ``date_exercice`` fields in the form. Each
+    component is sanitized and capitalized, then combined as
+    ``Chronogramme_<etablissement>_<nom>_<date>.xlsx``. If a file with the same
+    name already exists, a timestamp suffix is appended to ensure uniqueness.
 
     Parameters
     ----------
@@ -39,12 +53,21 @@ def handle_form_submission(form_data: Dict[str, Any]) -> Tuple[int, str]:
     """
 
     src_path = Path(form_data["file_path"])
+    if src_path.suffix.lower() != ".xlsx":
+        raise ValueError("File must be .xlsx")
+
     INPUTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    base = _sanitize(str(form_data.get("nom_chronogramme", "chronogramme")))
-    dest_name = f"{base}_{timestamp}{src_path.suffix}"
-    dest_path = INPUTS_DIR / dest_name
+    etab = _format_component(str(form_data.get("etablissement_nom", "")))
+    name = _format_component(str(form_data.get("nom_chronogramme", "")))
+    date = _format_component(str(form_data.get("date_exercice", "")))
+    base_parts = [part for part in [etab, name, date] if part]
+    base_name = "Chronogramme_" + "_".join(base_parts)
+    dest_path = INPUTS_DIR / f"{base_name}.xlsx"
+
+    if dest_path.exists():
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        dest_path = INPUTS_DIR / f"{base_name}_{timestamp}.xlsx"
 
     logger.info("Saving uploaded file to %s", dest_path)
     shutil.move(str(src_path), dest_path)

--- a/chronogram_pipeline/tests/test_form_handler.py
+++ b/chronogram_pipeline/tests/test_form_handler.py
@@ -1,6 +1,7 @@
 import sqlite3
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -22,7 +23,9 @@ def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
     src_file.write_text("data")
 
     form_data = {
-        "nom_chronogramme": "Test",
+        "nom_chronogramme": "Feuvre Sec",
+        "etablissement_nom": "CHU Bordeaux",
+        "date_exercice": "2025-09",
         "file_path": str(src_file),
     }
 
@@ -31,6 +34,9 @@ def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
     assert not src_file.exists()
     assert Path(dest_path).exists()
     assert chrono_id == 1
+    assert Path(dest_path).name.startswith(
+        "Chronogramme_CHU_Bordeaux_Feuvre_Sec_2025-09"
+    )
 
     with sqlite3.connect(db_path) as conn:
         cur = conn.execute(
@@ -38,4 +44,27 @@ def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
             (chrono_id,),
         )
         row = cur.fetchone()
-    assert row == ("Test", dest_path)
+    assert row == ("Feuvre Sec", dest_path)
+
+
+def test_handle_form_submission_rejects_non_xlsx(tmp_path, monkeypatch):
+    db_path = tmp_path / "chronogrammes.db"
+    monkeypatch.setattr(db_utils, "DEFAULT_DB", db_path)
+    monkeypatch.setattr("src.form_handler.DEFAULT_DB", db_path)
+    monkeypatch.setattr("src.form_handler.INPUTS_DIR", tmp_path / "inputs")
+
+    conn = db_utils.create_connection(db_path)
+    db_utils.init_tables(conn)
+    conn.close()
+
+    src_file = tmp_path / "upload.txt"
+    src_file.write_text("data")
+
+    form_data = {
+        "nom_chronogramme": "Test",
+        "file_path": str(src_file),
+    }
+
+    with pytest.raises(ValueError):
+        handle_form_submission(form_data)
+


### PR DESCRIPTION
## Summary
- enhance `handle_form_submission` to use a deterministic filename based on
  form fields
- validate that uploaded files are `.xlsx`
- update tests for new behaviour and add coverage for invalid file types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6284e9f48327b6640461232a7963