### PR TITLE
Implement structured Excel file saving

### DIFF
--- a/chronogram_pipeline/src/form_handler.py
+++ b/chronogram_pipeline/src/form_handler.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import re
 import shutil
-from datetime import datetime
+import unicodedata
+from datetime import datetime, date
 from pathlib import Path
 from typing import Tuple, Dict, Any
 
@@ -17,9 +18,61 @@ INPUTS_DIR = BASE_DIR / "data/inputs"
 
 
 def _sanitize(name: str) -> str:
-    """Return a filesystem safe version of ``name``."""
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("._-")
-    return cleaned or "chronogramme"
+    """Return a filesystem safe version of ``name``.
+
+    Accents and special characters are removed, spaces are replaced by
+    underscores and the result is lowercased.
+    """
+    normalized = unicodedata.normalize("NFKD", name)
+    ascii_name = normalized.encode("ascii", "ignore").decode("ascii")
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", ascii_name)
+    cleaned = cleaned.strip("._-")
+    return cleaned.lower() or "chronogramme"
+
+
+def _format_date(value: str | datetime | date) -> str:
+    """Return ``value`` formatted as ``YYYY-MM-DD`` if possible."""
+    if isinstance(value, (datetime, date)):
+        return value.strftime("%Y-%m-%d")
+    if isinstance(value, str):
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%Y/%m/%d"):
+            try:
+                dt = datetime.strptime(value, fmt)
+                return dt.strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+    return _sanitize(str(value))
+
+
+def save_excel_file(
+    src: str | Path,
+    etablissement_nom: str,
+    nom_chronogramme: str,
+    date_exercice: str | datetime | date,
+    inputs_dir: Path = INPUTS_DIR,
+) -> Path:
+    """Copy ``src`` to ``inputs_dir`` with a structured unique file name."""
+
+    src_path = Path(src)
+    if src_path.suffix.lower() != ".xlsx":
+        raise ValueError("Uploaded file must be a .xlsx Excel file")
+
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+
+    etab = _sanitize(etablissement_nom)
+    nom = _sanitize(nom_chronogramme)
+    date_str = _format_date(date_exercice)
+
+    base_name = f"Chronogramme_{etab}_{nom}_{date_str}".strip("_")
+    dest_name = f"{base_name}.xlsx"
+    dest_path = inputs_dir / dest_name
+    if dest_path.exists():
+        suffix = datetime.now().strftime("_%H%M%S")
+        dest_path = inputs_dir / f"{base_name}{suffix}.xlsx"
+
+    logger.info("Saving uploaded file to %s", dest_path)
+    shutil.copy(src_path, dest_path)
+    return dest_path
 
 
 def handle_form_submission(form_data: Dict[str, Any]) -> Tuple[int, str]:
@@ -38,16 +91,12 @@ def handle_form_submission(form_data: Dict[str, Any]) -> Tuple[int, str]:
         the stored Excel file.
     """
 
-    src_path = Path(form_data["file_path"])
-    INPUTS_DIR.mkdir(parents=True, exist_ok=True)
-
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    base = _sanitize(str(form_data.get("nom_chronogramme", "chronogramme")))
-    dest_name = f"{base}_{timestamp}{src_path.suffix}"
-    dest_path = INPUTS_DIR / dest_name
-
-    logger.info("Saving uploaded file to %s", dest_path)
-    shutil.move(str(src_path), dest_path)
+    dest_path = save_excel_file(
+        form_data["file_path"],
+        str(form_data.get("etablissement_nom", "")),
+        str(form_data.get("nom_chronogramme", "chronogramme")),
+        form_data.get("date_exercice", ""),
+    )
 
     form_data["fichier_source"] = str(dest_path)
 

--- a/chronogram_pipeline/tests/test_form_handler.py
+++ b/chronogram_pipeline/tests/test_form_handler.py
@@ -1,14 +1,15 @@
 import sqlite3
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src import db_utils
-from src.form_handler import handle_form_submission
+from src.form_handler import handle_form_submission, save_excel_file
 
 
-def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
+def test_handle_form_submission_saves_and_inserts(tmp_path, monkeypatch):
     db_path = tmp_path / "chronogrammes.db"
     monkeypatch.setattr(db_utils, "DEFAULT_DB", db_path)
     monkeypatch.setattr("src.form_handler.DEFAULT_DB", db_path)
@@ -23,12 +24,14 @@ def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
 
     form_data = {
         "nom_chronogramme": "Test",
+        "etablissement_nom": "Hopitâl de Lyon",
+        "date_exercice": "2025/07/31",
         "file_path": str(src_file),
     }
 
     chrono_id, dest_path = handle_form_submission(form_data)
 
-    assert not src_file.exists()
+    assert src_file.exists()
     assert Path(dest_path).exists()
     assert chrono_id == 1
 
@@ -39,3 +42,27 @@ def test_handle_form_submission_moves_and_inserts(tmp_path, monkeypatch):
         )
         row = cur.fetchone()
     assert row == ("Test", dest_path)
+
+
+def test_save_excel_file_generates_structured_name(tmp_path):
+    src = tmp_path / "tempo.xlsx"
+    src.write_text("data")
+
+    dest = save_excel_file(
+        src,
+        "CHU Lyon",
+        "Exo Feu",
+        "2025-07-31",
+        inputs_dir=tmp_path,
+    )
+
+    assert dest.name.startswith("Chronogramme_chu_lyon_exo_feu_2025-07-31")
+    assert dest.exists()
+
+
+def test_save_excel_file_rejects_non_xlsx(tmp_path):
+    src = tmp_path / "tempo.xls"
+    src.write_text("data")
+
+    with pytest.raises(ValueError):
+        save_excel_file(src, "A", "B", "2023-01-01", inputs_dir=tmp_path)


### PR DESCRIPTION
## Summary
- sanitize strings and generate filenames using new save_excel_file helper
- use new helper in form_handler to save uploads
- extend form handler tests for structured naming and validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b63d382408327844c4ad3f62068a7