### PR TITLE
Implement IA call logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Base_chronogramme
-Projet de création du pipeline de données pour un base de chronogramme et d'injects
+Projet de création du pipeline de données pour un base de chronogramme et d'injects.
+
+## Journaux d'exécution
+
+Chaque lancement du pipeline crée un fichier `run_<horodatage>.log` dans
+`chronogram_pipeline/data/control/`. Ces journaux sont au format JSON et
+contiennent les messages techniques ainsi que les métriques de chaque étape du
+traitement. Ils permettent de tracer précisément les actions réalisées,
+notamment les appels à l'IA lors de la standardisation des en‑têtes.

--- a/chronogram_pipeline/README.md
+++ b/chronogram_pipeline/README.md
@@ -1,1 +1,6 @@
 # Chronogram Pipeline
+
+Ce projet fournit les briques de traitement du pipeline de chronogrammes.
+Un logger intégré crée un fichier `run_<horodatage>.log` à chaque exécution
+dans `data/control/`. Ce fichier répertorie chronologiquement les étapes,
+leurs durées et les décisions prises (heuristiques ou appels IA).

--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -159,11 +159,19 @@ def standardize_headers(
             base = file_name or "file"
             prompt_file = prompts_dir / f"{base}_header_{safe_header}.txt"
             prompt_file.write_text(prompt_text, encoding="utf-8")
-
             std = suggest(header_str, allowed)
             mapping[header_str] = std
             new_mapping = True
             method = "IA"
+            logger.info(
+                "IA header mapping",
+                extra={
+                    "event": "IA_CALL",
+                    "type": "header",
+                    "prompt": str(prompt_file.name),
+                    "response": std,
+                },
+            )
         log_rows.append((header_str, std, method))
         result.append(std)
 

--- a/chronogram_pipeline/tests/test_standardizer_logging.py
+++ b/chronogram_pipeline/tests/test_standardizer_logging.py
@@ -1,0 +1,42 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_standardize_headers_logs_ai_call(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHRONO_LOG_DIR", str(log_dir))
+
+    import importlib
+    import src.standardizer as standardizer
+    from src.logger import get_logger
+    importlib.reload(standardizer)
+    standardizer.logger = get_logger("std_test")
+    standardize_headers = standardizer.standardize_headers
+
+    mapping_csv = tmp_path / "mapping.csv"
+    mapping_csv.write_text("")
+
+    schema = tmp_path / "schema.yaml"
+    schema.write_text("fields:\n  - name: Destinataire\n")
+
+    prompts = tmp_path / "prompts"
+
+    def fake(header, allowed):
+        return "Destinataire"
+
+    standardize_headers(
+        ["Dest"],
+        mapping_csv=mapping_csv,
+        schema_path=schema,
+        prompts_dir=prompts,
+        gpt_suggest_header=fake,
+        file_name="sample",
+        log_xlsx=tmp_path / "log.xlsx",
+    )
+
+    log_file = sorted(log_dir.glob("run_*.log"))[-1]
+    entries = [json.loads(l) for l in log_file.read_text().splitlines()]
+    assert any(e.get("event") == "IA_CALL" and e.get("type") == "header" for e in entries)


### PR DESCRIPTION
## Summary
- log IA prompts and responses during header standardization
- document generation of `run_<timestamp>.log` files
- test IA logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b643fcdb4832799154042f08c8d8c