### PR TITLE
Fix test_form_handler imports

### DIFF
--- a/chronogram_pipeline/tests/test_form_handler.py
+++ b/chronogram_pipeline/tests/test_form_handler.py
@@ -7,8 +7,13 @@ from datetime import datetime, date
 from pathlib import Path
 from typing import Tuple, Dict, Any
 
-from chronogram_pipeline.src.logger import get_logger
-from chronogram_pipeline.src.db_utils import insert_chronogram, DEFAULT_DB, BASE_DIR
+import sys
+
+# allow imports when running tests from this directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.logger import get_logger
+from src.db_utils import insert_chronogram, DEFAULT_DB, BASE_DIR
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure test_form_handler works even when run from its folder

## Testing
- `python -m pytest -q`
- `cd chronogram_pipeline/tests && python -m pytest test_form_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b6a702d10832799a3b28a5e6c2408