### PR TITLE
Implement mappings_log history

### DIFF
--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Callable, Iterable, List, Mapping, Dict
+from datetime import datetime
 
 import pandas as pd
 import requests
@@ -13,6 +14,10 @@ from .logger import get_logger
 from .mapping_utils import normalize_text
 
 logger = get_logger(__name__)
+
+# Default path for the mappings log file
+CONTROL_DIR = Path(os.getenv("CHRONO_LOG_DIR", Path(__file__).resolve().parents[1] / "data/control"))
+DEFAULT_MAPPING_LOG = CONTROL_DIR / "mappings_log.xlsx"
 
 # Type of the callback used to suggest a header
 SuggestFunc = Callable[[str, Iterable[str]], str]
@@ -59,6 +64,41 @@ def _load_schema(schema_path: Path | None) -> List[str]:
     return []
 
 
+def _append_mapping_log(
+    rows: Iterable[tuple[str, str, str]],
+    log_path: Path,
+    *,
+    chrono_id: int | None = None,
+) -> None:
+    """Append mapping *rows* to *log_path* with optional chronogram id."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    columns = [
+        "id_chronogramme",
+        "nom_original",
+        "champ_standard",
+        "methode",
+        "horodatage",
+    ]
+
+    if log_path.exists():
+        df_log = pd.read_excel(log_path)
+    else:
+        df_log = pd.DataFrame(columns=columns)
+
+    for orig, std, method in rows:
+        df_log.loc[len(df_log)] = [
+            chrono_id if chrono_id is not None else "",
+            normalize_text(orig),
+            normalize_text(std),
+            method,
+            timestamp,
+        ]
+
+    df_log.to_excel(log_path, index=False)
+
+
 def _default_mistral_call(header: str, allowed: Iterable[str]) -> str:
     api_key = os.getenv("MISTRAL_API_KEY")
     if not api_key:
@@ -86,6 +126,7 @@ def standardize_headers_rules(
     *,
     mapping_csv: Path,
     log_xlsx: Path | None = None,
+    id_chronogramme: int | None = None,
 ) -> List[str]:
     """Standardize headers using only local dictionary rules."""
     mapping = _load_mapping_normalized(mapping_csv)
@@ -102,16 +143,8 @@ def standardize_headers_rules(
         log_rows.append((header_str, std, "règle"))
         result.append(std)
 
-    if log_xlsx:
-        if log_xlsx.exists():
-            df_log = pd.read_excel(log_xlsx)
-        else:
-            df_log = pd.DataFrame(
-                columns=["En-tête original", "En-tête standard", "Méthode"]
-            )
-        for row in log_rows:
-            df_log.loc[len(df_log)] = row
-        df_log.to_excel(log_xlsx, index=False)
+    log_file = log_xlsx or DEFAULT_MAPPING_LOG
+    _append_mapping_log(log_rows, log_file, chrono_id=id_chronogramme)
 
     for orig, std, method in log_rows:
         logger.info("Header '%s' -> '%s' via %s", orig, std, method)
@@ -128,6 +161,7 @@ def standardize_headers(
     gpt_suggest_header: SuggestFunc | None = None,
     file_name: str | None = None,
     log_xlsx: Path | None = None,
+    id_chronogramme: int | None = None,
 ) -> List[str]:
     """Return list of standardized headers using dictionary and optional AI."""
     mapping = _load_mapping(mapping_csv)
@@ -178,14 +212,8 @@ def standardize_headers(
     if new_mapping:
         _save_mapping(mapping_csv, mapping)
 
-    if log_xlsx:
-        if log_xlsx.exists():
-            df_log = pd.read_excel(log_xlsx)
-        else:
-            df_log = pd.DataFrame(columns=["En-tête original", "En-tête standard", "Méthode"])
-        for row in log_rows:
-            df_log.loc[len(df_log)] = row
-        df_log.to_excel(log_xlsx, index=False)
+    log_file = log_xlsx or DEFAULT_MAPPING_LOG
+    _append_mapping_log(log_rows, log_file, chrono_id=id_chronogramme)
 
     for orig, std, method in log_rows:
         logger.info("Header '%s' -> '%s' via %s", orig, std, method)

--- a/chronogram_pipeline/tests/test_mappings_log_default.py
+++ b/chronogram_pipeline/tests/test_mappings_log_default.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_default_log_path(tmp_path, monkeypatch):
+    control_dir = tmp_path / "ctrl"
+    monkeypatch.setenv("CHRONO_LOG_DIR", str(control_dir))
+
+    import src.standardizer as standardizer
+    importlib.reload(standardizer)
+
+    mapping_csv = tmp_path / "map.csv"
+    mapping_csv.write_text("En-tete original,En-tete standard\nA,B\n")
+
+    standardizer.standardize_headers_rules(["A"], mapping_csv=mapping_csv)
+
+    log_file = control_dir / "mappings_log.xlsx"
+    assert log_file.exists()
+    df = pd.read_excel(log_file)
+    assert df.shape[0] == 1

--- a/chronogram_pipeline/tests/test_standardizer_headers.py
+++ b/chronogram_pipeline/tests/test_standardizer_headers.py
@@ -25,6 +25,7 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
 
     headers = ["Descriptif", "Destinataires"]
 
+    log_xlsx = tmp_path / "log.xlsx"
     out = standardize_headers(
         headers,
         mapping_csv=mapping_csv,
@@ -32,7 +33,8 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
         prompts_dir=prompts_dir,
         gpt_suggest_header=fake_gpt,
         file_name="testfile",
-        log_xlsx=tmp_path / "log.xlsx",
+        log_xlsx=log_xlsx,
+        id_chronogramme=10,
     )
 
     assert out == ["Contenu", "Destinataire"]
@@ -42,3 +44,5 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
     assert "Destinataires" in df["En-tête original"].values
     # prompt saved
     assert (prompts_dir / "testfile_header_Destinataires.txt").exists()
+    log_df = pd.read_excel(log_xlsx)
+    assert set(log_df["id_chronogramme"]) == {10}

--- a/chronogram_pipeline/tests/test_standardizer_rules.py
+++ b/chronogram_pipeline/tests/test_standardizer_rules.py
@@ -16,10 +16,20 @@ def test_standardize_headers_rules(tmp_path):
     log_xlsx = tmp_path / "log.xlsx"
     headers = ["Descriptif", "destinataires", "Inconnu"]
 
-    out = standardize_headers_rules(headers, mapping_csv=mapping_csv, log_xlsx=log_xlsx)
+    out = standardize_headers_rules(
+        headers, mapping_csv=mapping_csv, log_xlsx=log_xlsx, id_chronogramme=42
+    )
 
     assert out == ["Contenu", "Destinataire", ""]
 
     df = pd.read_excel(log_xlsx)
+    assert list(df.columns) == [
+        "id_chronogramme",
+        "nom_original",
+        "champ_standard",
+        "methode",
+        "horodatage",
+    ]
     assert df.shape[0] == 3
-    assert (df["Méthode"] == "règle").all()
+    assert set(df["id_chronogramme"]) == {42}
+    assert (df["methode"] == "règle").all()


### PR DESCRIPTION
## Summary
- add mappings log location constants and helper
- write mapping rows with header, method and timestamp
- allow passing chronogram id when standardizing headers
- log mappings in default `mappings_log.xlsx`
- adjust tests for new columns
- cover default log path with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6df9b8508327a9c948d1d5ea94a7