### PR TITLE
Add helper to insert sanitized metadata into DB

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -1,4 +1,4 @@
-from .db_utils import create_connection, init_databases
+from .db_utils import create_connection, init_databases, insert_chronogram_metadata
 from .mapping_utils import (
     detect_main_sheet,
     find_data_table,
@@ -18,4 +18,5 @@ __all__ = [
     "standardize_headers",
     "standardize_headers_rules",
     "PipelineLogger",
+    "insert_chronogram_metadata",
 ]

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -1,6 +1,7 @@
 from .logger import get_logger
 import sqlite3
-from datetime import datetime
+import unicodedata
+from datetime import datetime, date
 from pathlib import Path
 from typing import Dict, Any
 
@@ -95,3 +96,68 @@ def insert_chronogram(record: Dict[str, Any], db_path: Path | None = None) -> in
         chrono_id = int(cur.lastrowid)
         logger.debug("Inserted chronogram with id %s", chrono_id)
         return chrono_id
+
+
+def _clean_string(value: Any) -> str:
+    """Return a trimmed ASCII representation of ``value``."""
+    text = "" if value is None else str(value).strip()
+    normalized = unicodedata.normalize("NFKD", text)
+    return normalized.encode("ascii", "ignore").decode("ascii")
+
+
+def _format_date(value: Any) -> str:
+    """Return ``value`` formatted as ``YYYY-MM-DD`` when possible."""
+    if isinstance(value, (datetime, date)):
+        return value.strftime("%Y-%m-%d")
+    if isinstance(value, str):
+        value = value.strip()
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%Y/%m/%d"):
+            try:
+                return datetime.strptime(value, fmt).strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+    return _clean_string(value)
+
+
+def insert_chronogram_metadata(metadata: Dict[str, Any], db_path: Path | None = None) -> int:
+    """Validate, clean and insert chronogram metadata.
+
+    Parameters
+    ----------
+    metadata : Dict[str, Any]
+        Raw metadata coming from the form submission.
+    db_path : Path, optional
+        SQLite database path. Defaults to ``DEFAULT_DB``.
+
+    Returns
+    -------
+    int
+        The generated ``id_chronogramme``.
+    """
+
+    required = [
+        "nom_chronogramme",
+        "date_exercice",
+        "lieu_exercice",
+        "etablissement_nom",
+        "etablissement_type",
+        "submitter",
+        "nom_fichier_excel",
+    ]
+    missing = [field for field in required if not metadata.get(field)]
+    if missing:
+        raise ValueError(f"Missing required metadata fields: {', '.join(missing)}")
+
+    record = {
+        "nom_chronogramme": _clean_string(metadata["nom_chronogramme"]),
+        "date_exercice": _format_date(metadata["date_exercice"]),
+        "lieu_exercice": _clean_string(metadata["lieu_exercice"]),
+        "etablissement_nom": _clean_string(metadata["etablissement_nom"]),
+        "etablissement_type": _clean_string(metadata["etablissement_type"]),
+        "submitter": _clean_string(metadata["submitter"]),
+        "date_soumission": datetime.utcnow().isoformat(),
+        "fichier_source": _clean_string(metadata["nom_fichier_excel"]),
+        "nb_injects": int(metadata.get("nb_injects", 0) or 0),
+    }
+
+    return insert_chronogram(record, db_path=db_path)

--- a/chronogram_pipeline/tests/test_metadata_insertion.py
+++ b/chronogram_pipeline/tests/test_metadata_insertion.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import sqlite3
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.db_utils import insert_chronogram_metadata
+
+
+def test_insert_chronogram_metadata(tmp_path):
+    db_path = tmp_path / "chronos.db"
+    metadata = {
+        "nom_chronogramme": "Exercice Test",
+        "date_exercice": "2024-01-01",
+        "lieu_exercice": "Lyon",
+        "etablissement_nom": "CHU",
+        "etablissement_type": "Hopital",
+        "submitter": "Bob",
+        "nom_fichier_excel": "Chronogramme_CHU_Test_2024.xlsx",
+        "nb_injects": 5,
+    }
+    chrono_id = insert_chronogram_metadata(metadata, db_path=db_path)
+    assert isinstance(chrono_id, int)
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT nom_chronogramme, date_exercice, fichier_source, nb_injects FROM Chronogrammes WHERE id_chronogramme=?",
+            (chrono_id,),
+        )
+        row = cur.fetchone()
+
+    assert row == (
+        "Exercice Test",
+        "2024-01-01",
+        "Chronogramme_CHU_Test_2024.xlsx",
+        5,
+    )


### PR DESCRIPTION
## Summary
- expose new utility `insert_chronogram_metadata` for validated metadata insertion
- export helper from package
- test metadata insertion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6df54248832799c42ce70c35397d