### PR TITLE
Implement dataframe cleaning utilities

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -6,6 +6,13 @@ from .mapping_utils import (
     update_mapping_headers,
 )
 from .standardizer import standardize_headers, standardize_headers_rules
+from .data_cleaner import (
+    clean_data,
+    drop_empty_cols,
+    drop_empty_rows,
+    remove_parasitic_rows,
+    unmerge_cells,
+)
 from .pipeline_logger import PipelineLogger
 
 __all__ = [
@@ -17,5 +24,10 @@ __all__ = [
     "update_mapping_headers",
     "standardize_headers",
     "standardize_headers_rules",
+    "unmerge_cells",
+    "drop_empty_rows",
+    "drop_empty_cols",
+    "remove_parasitic_rows",
+    "clean_data",
     "PipelineLogger",
 ]

--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -1,0 +1,62 @@
+"""Data cleaning utilities for chronogram tables."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def unmerge_cells(df: pd.DataFrame) -> pd.DataFrame:
+    """Propagate merged cell values vertically and horizontally."""
+    result = df.copy()
+    result.fillna(method="ffill", inplace=True)
+    result.fillna(method="ffill", axis=1, inplace=True)
+    return result
+
+
+def drop_empty_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove rows that are completely empty or contain only blanks."""
+    df = df.copy()
+    df.replace(r"^\s*$", pd.NA, regex=True, inplace=True)
+    df.dropna(axis=0, how="all", inplace=True)
+    return df
+
+
+def drop_empty_cols(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove columns that contain no data below the header row."""
+    df = df.copy()
+    df.replace(r"^\s*$", pd.NA, regex=True, inplace=True)
+    data = df.iloc[1:] if len(df) > 1 else df
+    empty = [col for col in df.columns if data[col].isna().all()]
+    df.drop(columns=empty, inplace=True)
+    return df
+
+
+def remove_parasitic_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows like 'TOTAL' or 'Phase X' that do not contain data."""
+    df = df.copy()
+    keywords = ("total", "phase")
+
+    def is_parasitic(row) -> bool:
+        cells = [
+            str(c).strip().lower()
+            for c in row
+            if not pd.isna(c) and str(c).strip() != ""
+        ]
+        if len(cells) == 1:
+            val = cells[0]
+            return any(val.startswith(k) for k in keywords)
+        return False
+
+    mask = df.apply(is_parasitic, axis=1)
+    df = df[~mask]
+    return df
+
+
+def clean_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` cleaned from empty/parasitic rows and columns."""
+    df = unmerge_cells(df)
+    df = drop_empty_rows(df)
+    df = drop_empty_cols(df)
+    df = remove_parasitic_rows(df)
+    df.reset_index(drop=True, inplace=True)
+    return df

--- a/chronogram_pipeline/tests/test_data_cleaner.py
+++ b/chronogram_pipeline/tests/test_data_cleaner.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.data_cleaner import clean_data
+
+
+def test_clean_data_removes_noise():
+    df = pd.DataFrame(
+        [
+            ["H1", "H2", "Empty"],
+            ["val1", "val2", ""],
+            ["TOTAL", "", ""],
+            ["phase 1", "", ""],
+            [None, None, None],
+        ]
+    )
+
+    out = clean_data(df)
+
+    # Header row plus one data row should remain
+    assert out.shape == (2, 2)
+    assert list(out.iloc[0]) == ["H1", "H2"]
+    assert list(out.iloc[1]) == ["val1", "val2"]


### PR DESCRIPTION
## Summary
- add new `data_cleaner` module for cleaning chronogram tables
- expose cleaning helpers in package `__init__`
- test noise removal in `clean_data`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6e6aa6908327981b8ad7827b4462