### PR TITLE
Add enricher utility for inject metadata

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -19,6 +19,7 @@ from .data_cleaner import (
     unmerge_cells,
 )
 from .pipeline_logger import PipelineLogger
+from .enricher import enrich_data
 
 __all__ = [
     "create_connection",
@@ -38,4 +39,5 @@ __all__ = [
     "clean_data",
     "PipelineLogger",
     "insert_chronogram_metadata",
+    "enrich_data",
 ]

--- a/chronogram_pipeline/src/enricher.py
+++ b/chronogram_pipeline/src/enricher.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def enrich_data(
+    df: pd.DataFrame,
+    *,
+    id_chronogramme: int,
+    etablissement_nom: str,
+    etablissement_type: str,
+    nom_chronogramme: str,
+    date_exercice: str,
+) -> pd.DataFrame:
+    """Add contextual metadata columns and inject numbering.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Clean and standardised table of injects.
+    id_chronogramme : int
+        Identifier of the parent chronogram.
+    etablissement_nom : str
+        Establishment name.
+    etablissement_type : str
+        Establishment type.
+    nom_chronogramme : str
+        Chronogram name.
+    date_exercice : str
+        Exercise date.
+
+    Returns
+    -------
+    DataFrame
+        The enriched DataFrame ready for database insertion.
+    """
+    data = df.copy()
+
+    # add context columns
+    data["id_chronogramme"] = id_chronogramme
+    data["etablissement_nom"] = etablissement_nom
+    data["etablissement_type"] = etablissement_type
+    data["nom_chronogramme"] = nom_chronogramme
+    data["date_exercice"] = date_exercice
+
+    id_col = "ID_inject"
+    if id_col not in data.columns or data[id_col].astype(str).str.strip().replace("nan", "").eq("").all():
+        # create sequential numero_inject column
+        data["numero_inject"] = list(range(1, len(data) + 1))
+        logger.info("numero_inject generated", extra={"event": "AUTO_NUM"})
+    else:
+        mask = data[id_col].isna() | (data[id_col].astype(str).str.strip() == "")
+        if mask.any():
+            seq = range(1, mask.sum() + 1)
+            data.loc[mask, id_col] = list(seq)
+            logger.info("Missing ID_inject filled", extra={"event": "AUTO_NUM"})
+
+    data["nb_injects"] = len(data)
+    return data

--- a/chronogram_pipeline/tests/test_enricher.py
+++ b/chronogram_pipeline/tests/test_enricher.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.enricher import enrich_data
+
+
+def test_enrich_data_generates_ids(tmp_path):
+    df = pd.DataFrame({"Contenu": ["A", "B"]})
+
+    out = enrich_data(
+        df,
+        id_chronogramme=1,
+        etablissement_nom="CHU",
+        etablissement_type="Hopital",
+        nom_chronogramme="Test",
+        date_exercice="2024-01-01",
+    )
+
+    assert list(out["numero_inject"]) == [1, 2]
+    assert list(out["nb_injects"].unique()) == [2]
+    assert (out["id_chronogramme"] == 1).all()
+    assert (out["etablissement_nom"] == "CHU").all()
+    assert (out["etablissement_type"] == "Hopital").all()
+
+
+def test_enrich_data_completes_missing_ids(tmp_path):
+    df = pd.DataFrame({"ID_inject": ["A", None, "", "B"]})
+
+    out = enrich_data(
+        df,
+        id_chronogramme=2,
+        etablissement_nom="CH",
+        etablissement_type="Centre",
+        nom_chronogramme="Demo",
+        date_exercice="2025-01-01",
+    )
+
+    assert out["ID_inject"].tolist() == ["A", 1, 2, "B"]
+    assert list(out["nb_injects"].unique()) == [4]
+


### PR DESCRIPTION
## Summary
- add `enricher.py` to attach chronogram context and compute numbering
- expose `enrich_data` in package init
- test metadata enrichment logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b72a8dbac8327a103d235786bb88d