### PR TITLE
Add inject insertion utilities

### DIFF
--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -4,6 +4,7 @@ import unicodedata
 from datetime import datetime, date
 from pathlib import Path
 from typing import Dict, Any
+import pandas as pd
 
 logger = get_logger(__name__)
 
@@ -161,3 +162,65 @@ def insert_chronogram_metadata(metadata: Dict[str, Any], db_path: Path | None = 
     }
 
     return insert_chronogram(record, db_path=db_path)
+
+
+def insert_injects(df, db_path: Path | None = None) -> int:
+    """Insert multiple injects from DataFrame and return number inserted."""
+    import pandas as pd
+
+    if df is None or len(df) == 0:
+        return 0
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    db_path = db_path or DEFAULT_DB
+    columns = [
+        "id_chronogramme",
+        "id_inject",
+        "horodatage",
+        "description",
+        "emetteur",
+        "destinataire",
+        "type_inject",
+        "modalite",
+        "phase_exercice",
+        "observations",
+        "etablissement_nom",
+        "etablissement_type",
+    ]
+
+    rows = []
+    for _, row in df.iterrows():
+        entry = [row.get(col) for col in columns]
+        rows.append(entry)
+
+    placeholders = ", ".join("?" for _ in columns)
+    sql = f"INSERT INTO Injects ({', '.join(columns)}) VALUES ({placeholders})"
+
+    with create_connection(db_path) as conn:
+        init_tables(conn)
+        conn.executemany(sql, rows)
+        conn.commit()
+
+    logger.info("Inserted %s injects", len(rows))
+    return len(rows)
+
+
+def update_chronogram_stats(id_chronogramme: int, df, db_path: Path | None = None) -> None:
+    """Update nb_injects for a chronogram using DataFrame length."""
+    import pandas as pd
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    nb_injects = len(df)
+    db_path = db_path or DEFAULT_DB
+    with create_connection(db_path) as conn:
+        init_tables(conn)
+        conn.execute(
+            "UPDATE Chronogrammes SET nb_injects = ? WHERE id_chronogramme = ?",
+            (nb_injects, id_chronogramme),
+        )
+        conn.commit()
+    logger.debug("Updated chronogram %s with %s injects", id_chronogramme, nb_injects)
+

--- a/chronogram_pipeline/tests/test_injects_insertion.py
+++ b/chronogram_pipeline/tests/test_injects_insertion.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+import pandas as pd
+import sqlite3
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.db_utils import (
+    insert_chronogram_metadata,
+    insert_injects,
+    update_chronogram_stats,
+)
+
+
+def test_insert_injects_and_update_stats(tmp_path):
+    db_path = tmp_path / "chronos.db"
+    metadata = {
+        "nom_chronogramme": "Exercice Test",
+        "date_exercice": "2024-01-01",
+        "lieu_exercice": "Paris",
+        "etablissement_nom": "CHU",
+        "etablissement_type": "Hopital",
+        "submitter": "Alice",
+        "nom_fichier_excel": "Chrono.xlsx",
+    }
+
+    chrono_id = insert_chronogram_metadata(metadata, db_path=db_path)
+
+    df = pd.DataFrame({
+        "id_inject": [1, 2, 3, 4, 5],
+        "horodatage": ["T0", "T1", "T2", "T3", "T4"],
+        "description": ["a", "b", "c", "d", "e"],
+        "emetteur": ["X"] * 5,
+        "destinataire": ["Y"] * 5,
+        "type_inject": ["Info"] * 5,
+        "modalite": ["Mail"] * 5,
+        "phase_exercice": ["P"] * 5,
+        "observations": [""] * 5,
+        "id_chronogramme": [chrono_id] * 5,
+        "etablissement_nom": [metadata["etablissement_nom"]] * 5,
+        "etablissement_type": [metadata["etablissement_type"]] * 5,
+    })
+
+    inserted = insert_injects(df, db_path=db_path)
+    assert inserted == 5
+
+    update_chronogram_stats(chrono_id, df, db_path=db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM Injects WHERE id_chronogramme=?",
+            (chrono_id,),
+        )
+        count = cur.fetchone()[0]
+        cur = conn.execute(
+            "SELECT nb_injects FROM Chronogrammes WHERE id_chronogramme=?",
+            (chrono_id,),
+        )
+        nb = cur.fetchone()[0]
+
+    assert count == 5
+    assert nb == 5


### PR DESCRIPTION
## Summary
- support pandas import in `db_utils`
- add `insert_injects` and `update_chronogram_stats` helpers
- test inserting injects and updating chronogram stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7522544883279a7c939e92718010