### PR TITLE
Eliminate test warnings

### DIFF
--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -8,8 +8,8 @@ import pandas as pd
 def unmerge_cells(df: pd.DataFrame) -> pd.DataFrame:
     """Propagate merged cell values vertically and horizontally."""
     result = df.copy()
-    result.fillna(method="ffill", inplace=True)
-    result.fillna(method="ffill", axis=1, inplace=True)
+    result.ffill(inplace=True)
+    result.ffill(axis=1, inplace=True)
     return result
 
 

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -1,7 +1,7 @@
 from .logger import get_logger
 import sqlite3
 import unicodedata
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from pathlib import Path
 from typing import Dict, Any
 
@@ -155,7 +155,7 @@ def insert_chronogram_metadata(metadata: Dict[str, Any], db_path: Path | None = 
         "etablissement_nom": _clean_string(metadata["etablissement_nom"]),
         "etablissement_type": _clean_string(metadata["etablissement_type"]),
         "submitter": _clean_string(metadata["submitter"]),
-        "date_soumission": datetime.utcnow().isoformat(),
+        "date_soumission": datetime.now(timezone.utc).isoformat(),
         "fichier_source": _clean_string(metadata["nom_fichier_excel"]),
         "nb_injects": int(metadata.get("nb_injects", 0) or 0),
     }

--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Callable, Iterable, List, Mapping, Dict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import requests
@@ -72,7 +72,7 @@ def _append_mapping_log(
 ) -> None:
     """Append mapping *rows* to *log_path* with optional chronogram id."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     columns = [
         "id_chronogramme",


### PR DESCRIPTION
## Summary
- remove deprecated `fillna(method="ffill")` calls
- use timezone-aware timestamps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b761a8b80832798dc5f1f61a222be