### PR TITLE
Add batch processing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Chaque lancement du pipeline crée un fichier `run_<horodatage>.log` dans `chron
 Les différentes méthodes pour lancer le traitement (formulaire, ligne de commande ou appel automatisé) sont détaillées dans [docs/declenchement.md](docs/declenchement.md).
 
 Pour exécuter le pipeline sur tous les fichiers d'exemple présents dans `data/inputs/`,
-lancez simplement :
+pour traiter tous les exemples, lancez simplement :
 
 ```bash
 python scripts/run_all_inputs.py
+```
+Vous pouvez aussi indiquer un autre dossier contenant des fichiers Excel :
+```bash
+python scripts/run_all_inputs.py /chemin/vers/mes_fichiers
 ```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ Chaque lancement du pipeline crée un fichier `run_<horodatage>.log` dans `chron
 ## Déclenchement du pipeline
 
 Les différentes méthodes pour lancer le traitement (formulaire, ligne de commande ou appel automatisé) sont détaillées dans [docs/declenchement.md](docs/declenchement.md).
+
+Pour exécuter le pipeline sur tous les fichiers d'exemple présents dans `data/inputs/`,
+lancez simplement :
+
+```bash
+python scripts/run_all_inputs.py
+```

--- a/chronogram_pipeline/tests/test_batch_runner.py
+++ b/chronogram_pipeline/tests/test_batch_runner.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List
 import sys
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import scripts.run_all_inputs as batch
@@ -22,3 +23,16 @@ def test_process_all_invokes_pipeline(tmp_path, monkeypatch):
 
     assert calls == sorted(tmp_path.glob("*.xlsx"))
     assert results == [(tmp_path / "a.xlsx", 42), (tmp_path / "b.xlsx", 42)]
+
+
+def test_main_accepts_directory(tmp_path, monkeypatch, capsys):
+    (tmp_path / "a.xlsx").write_text("dummy")
+    monkeypatch.setattr(
+        "scripts.run_all_inputs.run_pipeline", lambda p: {"chrono_id": 1}
+    )
+    monkeypatch.setattr(sys, "argv", ["run_all_inputs", str(tmp_path)])
+
+    batch.main()
+
+    captured = capsys.readouterr().out
+    assert "a.xlsx: OK (1)" in captured

--- a/chronogram_pipeline/tests/test_batch_runner.py
+++ b/chronogram_pipeline/tests/test_batch_runner.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import List
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import scripts.run_all_inputs as batch
+
+
+def test_process_all_invokes_pipeline(tmp_path, monkeypatch):
+    calls: List[Path] = []
+
+    def fake_run_pipeline(path: Path):
+        calls.append(path)
+        return {"chrono_id": 42}
+
+    monkeypatch.setattr(batch, "run_pipeline", fake_run_pipeline)
+
+    (tmp_path / "a.xlsx").write_text("dummy")
+    (tmp_path / "b.xlsx").write_text("dummy")
+
+    results = batch.process_all(tmp_path)
+
+    assert calls == sorted(tmp_path.glob("*.xlsx"))
+    assert results == [(tmp_path / "a.xlsx", 42), (tmp_path / "b.xlsx", 42)]

--- a/docs/declenchement.md
+++ b/docs/declenchement.md
@@ -43,6 +43,10 @@ utilisez le script `scripts/run_all_inputs.py` :
 ```bash
 python scripts/run_all_inputs.py
 ```
+On peut aussi lui passer un dossier en argument :
+```bash
+python scripts/run_all_inputs.py /autre/dossier
+```
 
 ## Erreurs courantes
 

--- a/docs/declenchement.md
+++ b/docs/declenchement.md
@@ -35,6 +35,15 @@ Le fichier est stocké dans `data/inputs/` puis traité par `main.py`.
 
 Intégrez simplement l'appel à `main.py` dans votre tâche planifiée ou votre service. Veillez à ce que le `PYTHONPATH` pointe vers le projet et que le fichier Excel ainsi que les métadonnées soient accessibles. L'appel se fait avec les mêmes arguments que ci‑dessus.
 
+## 4. Traitement en lot des échantillons
+
+Pour exécuter la chaîne complète sur tous les fichiers `.xlsx` présents dans `data/inputs/`,
+utilisez le script `scripts/run_all_inputs.py` :
+
+```bash
+python scripts/run_all_inputs.py
+```
+
 ## Erreurs courantes
 
 - **Fichier manquant ou extension incorrecte** : `FileNotFoundError` ou `ValueError` si l'argument `--file` ne désigne pas un `.xlsx` existant.

--- a/scripts/run_all_inputs.py
+++ b/scripts/run_all_inputs.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
+import sys
+
+# ensure project root is importable when executed directly
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
 
 from chronogram_pipeline.src.logger import get_logger
 from main import run_pipeline
@@ -22,9 +28,8 @@ def process_all(inputs_dir: Path | None = None) -> List[Tuple[Path, int | None]]
         Tuples with the file path and the created chronogram id
         (``None`` if processing failed).
     """
-    base_dir = Path(__file__).resolve().parents[1]
     if inputs_dir is None:
-        inputs_dir = base_dir / "chronogram_pipeline" / "data" / "inputs"
+        inputs_dir = BASE_DIR / "chronogram_pipeline" / "data" / "inputs"
 
     files = sorted(p for p in inputs_dir.glob("*.xlsx") if p.is_file())
     logger = get_logger("batch_runner")
@@ -47,7 +52,20 @@ def process_all(inputs_dir: Path | None = None) -> List[Tuple[Path, int | None]]
 
 
 def main() -> None:
-    results = process_all()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Process every Excel file in a directory"
+    )
+    parser.add_argument(
+        "inputs_dir",
+        nargs="?",
+        type=Path,
+        help="Directory containing input .xlsx files (defaults to data/inputs)",
+    )
+    args = parser.parse_args()
+
+    results = process_all(args.inputs_dir)
     for file, chrono_id in results:
         status = "OK" if chrono_id is not None else "ERROR"
         cid = chrono_id if chrono_id is not None else "-"

--- a/scripts/run_all_inputs.py
+++ b/scripts/run_all_inputs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from chronogram_pipeline.src.logger import get_logger
+from main import run_pipeline
+
+
+def process_all(inputs_dir: Path | None = None) -> List[Tuple[Path, int | None]]:
+    """Run the pipeline on every ``.xlsx`` file in *inputs_dir*.
+
+    Parameters
+    ----------
+    inputs_dir: Path, optional
+        Directory containing Excel files. Defaults to
+        ``chronogram_pipeline/data/inputs`` next to this script.
+
+    Returns
+    -------
+    list of (Path, int | None)
+        Tuples with the file path and the created chronogram id
+        (``None`` if processing failed).
+    """
+    base_dir = Path(__file__).resolve().parents[1]
+    if inputs_dir is None:
+        inputs_dir = base_dir / "chronogram_pipeline" / "data" / "inputs"
+
+    files = sorted(p for p in inputs_dir.glob("*.xlsx") if p.is_file())
+    logger = get_logger("batch_runner")
+    results: List[Tuple[Path, int | None]] = []
+    if not files:
+        logger.info("No Excel files found in %s", inputs_dir)
+        return results
+
+    for xlsx in files:
+        logger.info("Processing %s", xlsx.name)
+        try:
+            res = run_pipeline(xlsx)
+            chrono_id = res.get("chrono_id")
+            logger.info("SUCCESS %s -> %s", xlsx.name, chrono_id)
+        except Exception as exc:  # pragma: no cover - just log failure
+            chrono_id = None
+            logger.exception("FAILED %s", xlsx, exc_info=exc)
+        results.append((xlsx, chrono_id))
+    return results
+
+
+def main() -> None:
+    results = process_all()
+    for file, chrono_id in results:
+        status = "OK" if chrono_id is not None else "ERROR"
+        cid = chrono_id if chrono_id is not None else "-"
+        print(f"{file.name}: {status} ({cid})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_all_inputs.py` helper to run pipeline on all example files
- document batch script usage in README and docs
- make `scripts` a package and test batch runner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b7a7f2da08327ac0a61d47d676f6b