### PR TITLE
Add KPI monitoring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Ce dépôt contient l'orchestration complète : extraction des fichiers Excel, 
 
 Chaque lancement du pipeline crée un fichier `run_<horodatage>.log` dans `chronogram_pipeline/data/control/`. Ces journaux sont au format JSON et contiennent les messages techniques ainsi que les métriques de chaque étape du traitement. Ils permettent de tracer précisément les actions réalisées, notamment les appels à l'IA lors de la standardisation des en‑têtes.
 
+Un script de suivi `scripts/monitor_kpi.py` agrège ces journaux et le fichier `mappings_log.xlsx` afin de générer un rapport `monitoring_log.md` avec les principaux indicateurs (taux d'automatisation, recours à l'IA, complétude des données...).
+
 
 ## Déclenchement du pipeline
 

--- a/docs/kpi_monitoring.md
+++ b/docs/kpi_monitoring.md
@@ -1,0 +1,33 @@
+# KPI de couverture du pipeline
+
+Ce document décrit les indicateurs utilisés pour suivre la qualité des traitements et les seuils d'alerte associés.
+
+## Définitions
+
+Soit `N` le nombre total d'éléments considérés pour un traitement (en‑têtes ou valeurs). Pour un identifiant de chronogramme donné :
+
+- **Taux de standardisation automatique** :
+  \[\text{auto\_rate} = \frac{N_{\text{règle}}}{N}\]
+  où `N_{règle}` est le nombre d'éléments standardisés par les règles locales.
+- **Taux de recours à l'IA** :
+  \[\text{ia\_rate} = \frac{N_{\text{IA}}}{N}\]
+  où `N_{IA}` est le nombre d'éléments standardisés grâce à une suggestion IA.
+- **Taux non résolu** :
+  \[\text{unresolved\_rate} = \frac{N_{\text{vide}}}{N}\]
+  où `N_{vide}` est le nombre d'éléments n'ayant reçu aucune correspondance.
+- **Complétude des injects** :
+  \[\text{completude} = \frac{\text{nombre de cellules renseignées}}{\text{nombre total de cellules attendues}}\]
+  Le calcul exclut les colonnes techniques `id_inject_global` et `id_chronogramme`.
+
+## Seuils d'alerte
+
+- **Alerte jaune** si l'un des critères suivants est dépassé :
+  - `ia_rate` > 40 %
+  - `unresolved_rate` > 10 %
+  - `completude` < 90 %
+- **Alerte rouge** si l'un des critères suivants est dépassé :
+  - `ia_rate` > 60 %
+  - `unresolved_rate` > 20 %
+  - `completude` < 70 %
+
+Les seuils sont ajustables selon la qualité réelle des fichiers analysés.

--- a/scripts/monitor_kpi.py
+++ b/scripts/monitor_kpi.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = BASE_DIR / "chronogram_pipeline" / "data" / "control"
+MAPPING_LOG = BASE_DIR / "chronogram_pipeline" / "config" / "mappings_log.xlsx"
+DB_PATH = BASE_DIR / "chronogram_pipeline" / "output" / "databases" / "chronogrammes.db"
+REPORT_PATH = LOG_DIR / "monitoring_log.md"
+
+
+def _load_chrono_id(log_file: Path) -> int | None:
+    """Return the chrono_id recorded in *log_file* summary."""
+    try:
+        with log_file.open() as fh:
+            for line in fh:
+                data = json.loads(line)
+                if data.get("event") == "SUMMARY":
+                    for step in data.get("steps", []):
+                        if step.get("name") == "INSERT_METADATA":
+                            return int(step.get("chrono_id"))
+    except Exception:
+        pass
+    return None
+
+
+def _compute_completeness(conn: sqlite3.Connection, chrono_id: int) -> float:
+    df = pd.read_sql(
+        "SELECT * FROM Injects WHERE id_chronogramme = ?",
+        conn,
+        params=(chrono_id,),
+    )
+    if df.empty:
+        return 0.0
+    cols = [c for c in df.columns if c not in {"id_inject_global", "id_chronogramme"}]
+    filled = df[cols].notna().sum().sum()
+    total = len(df) * len(cols)
+    return float(filled) / float(total) if total else 0.0
+
+
+def _format_pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def generate_report() -> None:
+    mapping_df = pd.read_excel(MAPPING_LOG) if MAPPING_LOG.exists() else pd.DataFrame()
+    records: Dict[str, Any] = {}
+    with sqlite3.connect(DB_PATH) as conn:
+        for log in sorted(LOG_DIR.glob("run_*.log")):
+            chrono_id = _load_chrono_id(log)
+            if chrono_id is None:
+                continue
+            subset = mapping_df[mapping_df["id_chronogramme"] == chrono_id]
+            total = len(subset)
+            auto_count = (subset["methode"] == "règle").sum()
+            ia_count = (subset["methode"] == "IA").sum()
+            unresolved = subset["champ_standard"].isna().sum() + (subset["champ_standard"] == "").sum()
+            auto_rate = auto_count / total if total else 0.0
+            ia_rate = ia_count / total if total else 0.0
+            unresolved_rate = unresolved / total if total else 0.0
+            completeness = _compute_completeness(conn, chrono_id)
+            alert = ""
+            if ia_rate > 0.6 or unresolved_rate > 0.2 or completeness < 0.7:
+                alert = "🔴"
+            elif ia_rate > 0.4 or unresolved_rate > 0.1 or completeness < 0.9:
+                alert = "⚠"
+            records[log.name] = {
+                "chrono_id": chrono_id,
+                "auto_rate": auto_rate,
+                "ia_rate": ia_rate,
+                "unresolved_rate": unresolved_rate,
+                "completeness": completeness,
+                "alert": alert,
+            }
+
+    lines = [
+        "| run log | id | auto | ia | non résolu | complétude | alerte |",
+        "|---------|----|------|----|------------|------------|--------|",
+    ]
+    for name, data in records.items():
+        lines.append(
+            f"| {name} | {data['chrono_id']} | {_format_pct(data['auto_rate'])} | "
+            f"{_format_pct(data['ia_rate'])} | {_format_pct(data['unresolved_rate'])} | "
+            f"{_format_pct(data['completeness'])} | {data['alert']} |"
+        )
+    REPORT_PATH.write_text("\n".join(lines), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    generate_report()


### PR DESCRIPTION
## Summary
- document how KPI monitoring works
- script `monitor_kpi.py` computes rates and produces `monitoring_log.md`
- mention monitoring in README

## Testing
- `pytest -q`
- `python scripts/monitor_kpi.py`

------
https://chatgpt.com/codex/tasks/task_e_688b810404f08327b019128ab3782333