### PR TITLE
Fix init_db import for direct execution

### DIFF
--- a/chronogram_pipeline/src/init_db.py
+++ b/chronogram_pipeline/src/init_db.py
@@ -1,7 +1,15 @@
 """Script to initialise SQLite databases for the chronogram pipeline."""
 from pathlib import Path
 
-from db_utils import init_databases
+try:
+    # allow execution with `python -m chronogram_pipeline.src.init_db`
+    from .db_utils import init_databases
+except ImportError:  # pragma: no cover - fallback for direct execution
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from db_utils import init_databases  # type: ignore
+
 from .logger import get_logger
 
 logger = get_logger(__name__)

--- a/docs/files_overview.md
+++ b/docs/files_overview.md
@@ -37,5 +37,6 @@ Contient le code principal du pipeline ainsi que les tests.
 - **`pipeline_logger.py`** et **`logger.py`** : configuration du logger JSON et gestion des messages durant l'exécution.
 - **`form_handler.py`** : traitement des formulaires côté front pour enregistrer un nouveau chronogramme.
 - **`manual_table_extractor.py`** : extraction manuelle d'une table lorsqu'aucune heuristique automatique ne fonctionne.
-- **`init_db.py`** : création initiale des bases de données et des tables.
+- **`init_db.py`** : création initiale des bases de données et des tables \
+  (à lancer avec `python -m chronogram_pipeline.src.init_db`).
 

--- a/retest_env.ps1
+++ b/retest_env.ps1
@@ -5,7 +5,7 @@ Write-Host "=== 📦 Installation des dépendances ==="
 pip install -r requirements.txt
 
 Write-Host "`n=== 🛠 Initialisation des bases SQLite ==="
-python .\chronogram_pipeline\src\init_db.py
+python -m chronogram_pipeline.src.init_db
 
 Write-Host "`n=== 📂 Vérification des fichiers .db ==="
 Get-ChildItem .\chronogram_pipeline\output\databases


### PR DESCRIPTION
## Summary
- allow running `init_db.py` as a module
- document how to launch `init_db.py`
- update environment script accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b83cb252483278cb4132e5762a902