### PR TITLE
Implement auto processing and archiving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.db
 chronogram_pipeline/data/control/*.log
+chronogram_pipeline/data/archive/raw_excels/*.xlsx

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ Vous pouvez aussi indiquer un autre dossier contenant des fichiers Excel :
 ```bash
 python scripts/run_all_inputs.py /chemin/vers/mes_fichiers
 ```
+Pour une automatisation complète, le script `scripts/process_new_inputs.py`
+traite tous les fichiers présents dans `data/inputs/` puis les déplace
+automatiquement dans `data/archive/raw_excels/`.

--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -1,4 +1,9 @@
-from .db_utils import create_connection, init_databases, insert_chronogram_metadata
+from .db_utils import (
+    create_connection,
+    init_databases,
+    insert_chronogram_metadata,
+    archive_file,
+)
 from .mapping_utils import (
     detect_main_sheet,
     find_data_table,
@@ -39,5 +44,6 @@ __all__ = [
     "clean_data",
     "PipelineLogger",
     "insert_chronogram_metadata",
+    "archive_file",
     "enrich_data",
 ]

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -5,6 +5,7 @@ from datetime import datetime, date, timezone
 from pathlib import Path
 from typing import Dict, Any
 import pandas as pd
+import shutil
 
 logger = get_logger(__name__)
 
@@ -223,4 +224,45 @@ def update_chronogram_stats(id_chronogramme: int, df, db_path: Path | None = Non
         )
         conn.commit()
     logger.debug("Updated chronogram %s with %s injects", id_chronogramme, nb_injects)
+
+
+def archive_file(
+    file_path: Path,
+    *,
+    chrono_id: int | None = None,
+    archive_dir: Path | None = None,
+) -> Path:
+    """Move ``file_path`` to the archive directory with a timestamped name.
+
+    Parameters
+    ----------
+    file_path : Path
+        Excel file that has been successfully processed.
+    chrono_id : int, optional
+        Chronogram identifier used to build the archive filename.
+    archive_dir : Path, optional
+        Destination directory. Defaults to ``data/archive/raw_excels`` in the
+        project tree.
+
+    Returns
+    -------
+    Path
+        Location of the archived file.
+    """
+
+    if archive_dir is None:
+        archive_dir = BASE_DIR / "data" / "archive" / "raw_excels"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = file_path.suffix
+    base = file_path.stem
+    if chrono_id is not None:
+        new_name = f"{base}_{chrono_id}_{timestamp}{suffix}"
+    else:
+        new_name = f"{base}_{timestamp}{suffix}"
+    dest = archive_dir / new_name
+    shutil.move(str(file_path), dest)
+    logger.info("Archived %s to %s", file_path, dest)
+    return dest
 

--- a/chronogram_pipeline/tests/test_archive_file.py
+++ b/chronogram_pipeline/tests/test_archive_file.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.db_utils import archive_file
+
+
+def test_archive_file_moves(tmp_path):
+    src = tmp_path / "sample.xlsx"
+    src.write_text("dummy")
+    archive_dir = tmp_path / "arc"
+
+    dest = archive_file(src, chrono_id=1, archive_dir=archive_dir)
+
+    assert dest.exists()
+    assert dest.parent == archive_dir
+    assert not src.exists()
+    assert "1" in dest.stem

--- a/docs/declenchement.md
+++ b/docs/declenchement.md
@@ -33,7 +33,11 @@ Le fichier est stocké dans `data/inputs/` puis traité par `main.py`.
 
 ## 3. Via un script automatisé (cron, API…)
 
-Intégrez simplement l'appel à `main.py` dans votre tâche planifiée ou votre service. Veillez à ce que le `PYTHONPATH` pointe vers le projet et que le fichier Excel ainsi que les métadonnées soient accessibles. L'appel se fait avec les mêmes arguments que ci‑dessus.
+Une tâche planifiée peut appeler le script `scripts/process_new_inputs.py` qui
+recherche tous les fichiers `.xlsx` dans `data/inputs/`. Pour chacun, il lance
+`main.py` puis déplace le fichier traité dans `data/archive/raw_excels/` avec un
+horodatage. Ce script constitue le point d'entrée recommandé pour automatiser le
+traitement continu.
 
 ## 4. Traitement en lot des échantillons
 

--- a/docs/files_overview.md
+++ b/docs/files_overview.md
@@ -9,6 +9,8 @@ Ce document résume brièvement le rôle des principaux fichiers du projet.
 - **`Specifications_techniques.md`** : spécifications détaillées du pipeline et des choix techniques.
 - **`retest_env.ps1`** : script PowerShell pour tester l'environnement (installation des dépendances et exécution des tests).
 - **`requirements.txt`** : dépendances Python nécessaires au fonctionnement du projet.
+- **`scripts/process_new_inputs.py`** : traite tous les fichiers présents dans
+  `data/inputs/` puis les archive automatiquement.
 
 ## Répertoire `config/`
 

--- a/main.py
+++ b/main.py
@@ -179,6 +179,8 @@ def run_pipeline(
 
     plog.summary()
 
+    archived = db_utils.archive_file(xlsx_file, chrono_id=chrono_id)
+
     log_dir_actual = Path(os.getenv("CHRONO_LOG_DIR", config_dir))
     logs = sorted(log_dir_actual.glob("run_*.log"))
     if not logs:
@@ -194,6 +196,7 @@ def run_pipeline(
         "enriched_df": df_enriched,
         "log_file": log_file,
         "mapping_log": mapping_log,
+        "archived_file": archived,
     }
 
 

--- a/scripts/process_new_inputs.py
+++ b/scripts/process_new_inputs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from chronogram_pipeline.src.logger import get_logger
+from chronogram_pipeline.src.db_utils import archive_file, BASE_DIR as DATA_BASE_DIR
+from main import run_pipeline
+
+
+def process_new(inputs_dir: Path | None = None) -> list[tuple[Path, int | None]]:
+    """Process and archive every Excel file found in *inputs_dir*."""
+    if inputs_dir is None:
+        inputs_dir = DATA_BASE_DIR / "data" / "inputs"
+
+    logger = get_logger("new_files")
+    files = sorted(p for p in inputs_dir.glob("*.xlsx") if p.is_file())
+    results: list[tuple[Path, int | None]] = []
+    for xlsx in files:
+        try:
+            logger.info("Processing %s", xlsx.name)
+            res = run_pipeline(xlsx)
+            cid = res.get("chrono_id")
+            archive_file(xlsx, chrono_id=cid)
+            logger.info("SUCCESS %s -> %s", xlsx.name, cid)
+        except Exception as exc:  # pragma: no cover - just log failure
+            logger.exception("FAILED %s", xlsx, exc_info=exc)
+            cid = None
+        results.append((xlsx, cid))
+    return results
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process new Excel files")
+    parser.add_argument(
+        "inputs_dir",
+        nargs="?",
+        type=Path,
+        help="Directory containing input .xlsx files (defaults to data/inputs)",
+    )
+    args = parser.parse_args()
+
+    results = process_new(args.inputs_dir)
+    for file, chrono_id in results:
+        status = "OK" if chrono_id is not None else "ERROR"
+        cid = chrono_id if chrono_id is not None else "-"
+        print(f"{file.name}: {status} ({cid})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- archive processed Excel files
- expose `archive_file` helper
- call `archive_file` at the end of `run_pipeline`
- add a script to process and archive all new inputs
- document the automation script
- ignore archived Excel files in git
- test the new archiving helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6fb8d57c832780888790ba34d8e0