### PR TITLE
Fix standalone init_db

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Ce dépôt contient l'orchestration complète : extraction des fichiers Excel, 
    ```bash
    python chronogram_pipeline/src/init_db.py
    ```
+   Vous pouvez également lancer le script depuis son dossier :
+   ```bash
+   cd chronogram_pipeline/src
+   python init_db.py
+   ```
+   ou via le module Python :
+   ```bash
+   python -m chronogram_pipeline.src.init_db
+   ```
 
 Pour les opérations de standardisation pilotées par l'IA, renseignez les clefs d'accès
 dans les variables d'environnement `OPENAI_API_KEY` ou `MISTRAL_API_KEY` selon

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -4,12 +4,14 @@ import unicodedata
 from datetime import datetime, date, timezone
 from pathlib import Path
 from typing import Dict, Any
+import os
 import pandas as pd
 
 logger = get_logger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parents[1]
-DEFAULT_DB = BASE_DIR / "output/databases/chronogrammes.db"
+DB_DIR = Path(os.getenv("OUTPUT_DB_PATH", BASE_DIR / "output/databases"))
+DEFAULT_DB = DB_DIR / "chronogrammes.db"
 
 CHRONO_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS Chronogrammes (

--- a/chronogram_pipeline/src/init_db.py
+++ b/chronogram_pipeline/src/init_db.py
@@ -1,23 +1,21 @@
 """Script to initialise SQLite databases for the chronogram pipeline."""
 from pathlib import Path
+import os
 
-try:
-    # allow execution with `python -m chronogram_pipeline.src.init_db`
-    from .db_utils import init_databases
-except ImportError:  # pragma: no cover - fallback for direct execution
-    import sys
-
-    sys.path.append(str(Path(__file__).resolve().parent))
-    from db_utils import init_databases  # type: ignore
-
-from .logger import get_logger
+from chronogram_pipeline.src.db_utils import init_databases
+from chronogram_pipeline.src.logger import get_logger
 
 logger = get_logger(__name__)
 
 
 def main() -> None:
     """Initialise the SQLite databases used by the pipeline."""
-    base_dir = Path(__file__).resolve().parents[1] / "output/databases"
+    base_dir = Path(
+        os.getenv(
+            "OUTPUT_DB_PATH",
+            Path(__file__).resolve().parents[1] / "output/databases",
+        )
+    )
     chrono_db = base_dir / "chronogrammes.db"
     injects_db = base_dir / "injects.db"
     logger.info("Creating databases in %s", base_dir)

--- a/chronogram_pipeline/tests/test_db_utils.py
+++ b/chronogram_pipeline/tests/test_db_utils.py
@@ -2,10 +2,13 @@ import sys
 from pathlib import Path
 import sqlite3
 
-# allow imports from project root
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# allow imports from project root and package
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "chronogram_pipeline"))
+sys.path.insert(0, str(REPO_ROOT))
 
 from src.db_utils import init_databases
+from chronogram_pipeline.src import init_db
 
 
 def table_exists(db_path: Path, table: str) -> bool:
@@ -26,3 +29,12 @@ def test_init_databases_creates_tables(tmp_path):
     assert injects_db.exists()
     assert table_exists(chrono_db, "Chronogrammes")
     assert table_exists(injects_db, "Injects")
+
+
+def test_init_db_main_creates_files(tmp_path, monkeypatch):
+    out_dir = tmp_path / "databases"
+    monkeypatch.setenv("OUTPUT_DB_PATH", str(out_dir))
+    init_db.main()
+    files = {f.name for f in out_dir.glob("*.db")}
+    assert "chronogrammes.db" in files
+    assert "injects.db" in files


### PR DESCRIPTION
## Summary
- use absolute imports and env override in `init_db.py`
- allow overriding DB directory in `db_utils`
- expand docs on running init_db script
- test creating DBs via `init_db.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c735c4a7c8327a62821106385a2b4