### PR TITLE
Handle Series in unmerge_cells

### DIFF
--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -8,8 +8,18 @@ import pandas as pd
 def unmerge_cells(df: pd.DataFrame) -> pd.DataFrame:
     """Propagate merged cell values vertically and horizontally."""
     result = df.copy()
-    result.ffill(inplace=True)
-    result.ffill(axis=1, inplace=True)
+
+    # Forward-fill downwards first to handle vertical merges
+    result = result.ffill()
+
+    # ``result`` might be a Series if ``df`` was not a DataFrame.  ``Series``
+    # does not support ``ffill`` with ``axis`` so convert it to a single-row
+    # DataFrame before applying the horizontal fill.
+    if isinstance(result, pd.Series):
+        result = result.to_frame().T
+
+    # Propagate values horizontally (left -> right)
+    result = result.ffill(axis=1)
     return result
 
 

--- a/chronogram_pipeline/tests/test_data_cleaner.py
+++ b/chronogram_pipeline/tests/test_data_cleaner.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.data_cleaner import clean_data
+from src.data_cleaner import clean_data, unmerge_cells
 
 
 def test_clean_data_removes_noise():
@@ -24,3 +24,18 @@ def test_clean_data_removes_noise():
     assert out.shape == (2, 2)
     assert list(out.iloc[0]) == ["H1", "H2"]
     assert list(out.iloc[1]) == ["val1", "val2"]
+
+
+def test_unmerge_cells_series_forward_fill():
+    raw = pd.DataFrame({
+        "A": ["val1", None, None],
+        "B": [None, None, "val2"],
+    })
+
+    # Call directly on a Series to emulate intermediate processing
+    series_input = raw.loc[0]
+    out = unmerge_cells(series_input)
+    assert isinstance(out, pd.DataFrame)
+    # Horizontal propagation should duplicate the value on the row
+    assert list(out.iloc[0]) == ["val1", "val1"]
+


### PR DESCRIPTION
## Summary
- ensure `unmerge_cells` works when receiving a Series
- test conversion of Series to DataFrame

## Testing
- `pytest -q`
- `python main.py "chronogram_pipeline/data/inputs/Chronogramme sur mesure.xlsx" | grep -A1 CLEAN_DATA`
- `python main.py 'chronogram_pipeline/data/inputs/Kit intermédiaire.xlsx' | grep -A1 CLEAN_DATA`


------
https://chatgpt.com/codex/tasks/task_e_688c731f682c83279fd1deb68dac0c02