### PR TITLE
Add schema-based column selection and inject ID formatting

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -25,6 +25,7 @@ from .data_cleaner import (
 )
 from .pipeline_logger import PipelineLogger
 from .enricher import enrich_data
+from .schema_utils import apply_schema_columns, load_schema_fields
 
 __all__ = [
     "create_connection",
@@ -46,4 +47,6 @@ __all__ = [
     "insert_chronogram_metadata",
     "archive_file",
     "enrich_data",
+    "apply_schema_columns",
+    "load_schema_fields",
 ]

--- a/chronogram_pipeline/src/enricher.py
+++ b/chronogram_pipeline/src/enricher.py
@@ -47,17 +47,10 @@ def enrich_data(
     data["nom_chronogramme"] = nom_chronogramme
     data["date_exercice"] = date_exercice
 
-    id_col = "ID_inject"
-    if id_col not in data.columns or data[id_col].astype(str).str.strip().replace("nan", "").eq("").all():
-        # create sequential numero_inject column
-        data["numero_inject"] = list(range(1, len(data) + 1))
-        logger.info("numero_inject generated", extra={"event": "AUTO_NUM"})
-    else:
-        mask = data[id_col].isna() | (data[id_col].astype(str).str.strip() == "")
-        if mask.any():
-            seq = range(1, mask.sum() + 1)
-            data.loc[mask, id_col] = list(seq)
-            logger.info("Missing ID_inject filled", extra={"event": "AUTO_NUM"})
+    # sequential numbering and unique inject identifier
+    data["numero"] = list(range(1, len(data) + 1))
+    data["id_inject"] = [f"C{id_chronogramme:03d}_L{num:03d}" for num in data["numero"]]
+    logger.info("numero generated", extra={"event": "AUTO_NUM"})
 
     data["nb_injects"] = len(data)
     return data

--- a/chronogram_pipeline/src/schema_utils.py
+++ b/chronogram_pipeline/src/schema_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+import yaml
+
+
+def load_schema_fields(schema_path: Path) -> list[str]:
+    """Return the list of field names defined in *schema_path*."""
+    if not schema_path or not schema_path.exists():
+        return []
+    data = yaml.safe_load(schema_path.read_text()) or {}
+    return [str(f.get("name")) for f in data.get("fields", []) if f.get("name")]
+
+
+def apply_schema_columns(df: pd.DataFrame, schema_path: Path) -> pd.DataFrame:
+    """Return ``df`` with only columns defined in ``schema_path``.
+
+    Missing columns are created with ``pd.NA`` and the order of columns
+    follows the schema definition. If the schema is empty, ``df`` is
+    returned unchanged.
+    """
+    fields = load_schema_fields(schema_path)
+    if not fields:
+        return df
+
+    result = pd.DataFrame(index=df.index)
+    for field in fields:
+        if field in df.columns:
+            result[field] = df[field]
+        else:
+            result[field] = pd.NA
+    return result

--- a/chronogram_pipeline/tests/test_enricher.py
+++ b/chronogram_pipeline/tests/test_enricher.py
@@ -19,7 +19,8 @@ def test_enrich_data_generates_ids(tmp_path):
         date_exercice="2024-01-01",
     )
 
-    assert list(out["numero_inject"]) == [1, 2]
+    assert list(out["numero"]) == [1, 2]
+    assert out["id_inject"].tolist() == ["C001_L001", "C001_L002"]
     assert list(out["nb_injects"].unique()) == [2]
     assert (out["id_chronogramme"] == 1).all()
     assert (out["etablissement_nom"] == "CHU").all()
@@ -38,6 +39,7 @@ def test_enrich_data_completes_missing_ids(tmp_path):
         date_exercice="2025-01-01",
     )
 
-    assert out["ID_inject"].tolist() == ["A", 1, 2, "B"]
+    assert list(out["numero"]) == [1, 2, 3, 4]
+    assert out["id_inject"].tolist() == ["C002_L001", "C002_L002", "C002_L003", "C002_L004"]
     assert list(out["nb_injects"].unique()) == [4]
 

--- a/chronogram_pipeline/tests/test_main_pipeline.py
+++ b/chronogram_pipeline/tests/test_main_pipeline.py
@@ -13,13 +13,17 @@ def create_config(dir: Path) -> Path:
     config = dir / "cfg"
     config.mkdir()
     (config / "mapping_headers.csv").write_text(
-        "En-tete original,En-tete standard\nHorodatage,horodatage\nDescriptif,description\nType d'inject,type_inject\n"
+        "En-tete original,En-tete standard\nHorodatage,horodatage\nDescriptif,description\nType d'inject,type\n"
     )
     (config / "mapping_values.csv").write_text(
-        "Colonne,Valeur brute,Valeur standard\ntype_inject,Majeur,Critique\n"
+        "Colonne,Valeur brute,Valeur standard\ntype,Majeur,structurant\n"
     )
     (config / "schema_definition.yaml").write_text(
-        "fields:\n  - name: type_inject\n    values: ['Critique', 'Important']\n"
+        "fields:\n"
+        "  - name: horodatage\n"
+        "  - name: description\n"
+        "  - name: type\n"
+        "    values: ['structurant', 'saturant']\n"
     )
     return config
 
@@ -46,7 +50,7 @@ def test_main_standardizes_headers(tmp_path):
     excel = tmp_path / "sample.xlsx"
     create_excel(excel)
     res = run_pipeline(excel, config_dir=config, log_dir=tmp_path, db_path=tmp_path / "db.sqlite")
-    assert list(res["df"].columns) == ["horodatage", "description", "type_inject"]
+    assert list(res["df"].columns) == ["horodatage", "description", "type"]
 
 
 def test_main_standardizes_values(tmp_path):
@@ -54,7 +58,7 @@ def test_main_standardizes_values(tmp_path):
     excel = tmp_path / "sample.xlsx"
     create_excel(excel)
     res = run_pipeline(excel, config_dir=config, log_dir=tmp_path, db_path=tmp_path / "db.sqlite")
-    assert list(res["df"]["type_inject"]) == ["Critique"]
+    assert list(res["df"]["type"]) == ["structurant"]
 
 
 def test_main_logs_are_created(tmp_path):

--- a/config/mapping_headers.csv
+++ b/config/mapping_headers.csv
@@ -1,4 +1,13 @@
 En-tete original,En-tete standard
-Descriptif,Contenu
-Destinataires potentiels,Destinataire
-Criteres d'acceptation (Definition of Done),Criteres d'acceptation
+Phase exercice,phase
+Phase_exercice,phase
+Statut,statut
+Type d'inject,type
+Horodatage,horodatage
+Emetteur,emetteur
+Destinataire,recepteur
+Modalite,nature
+Resume,resume
+Descriptif,contenu
+Actions,actions_attendues
+Commentaires,commentaires

--- a/config/mapping_values.csv
+++ b/config/mapping_values.csv
@@ -1,2 +1,3 @@
 Colonne,Valeur brute,Valeur standard
-Type d'inject,Majeur,Critique
+type,struct,structurant
+nature,visio,vidéo

--- a/config/schema_definition.yaml
+++ b/config/schema_definition.yaml
@@ -1,39 +1,51 @@
 ---
 fields:
-  - name: id_inject
-    type: string
-    required: true
-  - name: horodatage
+  - name: phase
     type: string
     required: false
-  - name: description
+    values: ["1", "2", "3", "4"]
+  - name: statut
+    type: string
+    required: false
+    values: ["joué", "annulé", "à jouer"]
+  - name: type
+    type: string
+    required: false
+    values: ["structurant", "saturant"]
+  - name: horodatage
     type: string
     required: false
   - name: emetteur
     type: string
     required: false
-  - name: destinataire
+  - name: recepteur
     type: string
     required: false
-  - name: type_inject
+  - name: nature
+    type: string
+    required: false
+    values: ["mail", "appel", "SMS", "vidéo", "Weezer", "oral"]
+  - name: resume
+    type: string
+    required: false
+  - name: contenu
+    type: string
+    required: false
+  - name: actions_attendues
+    type: string
+    required: false
+  - name: commentaires
+    type: string
+    required: false
+  - name: id_inject
     type: string
     required: true
-    values: ["Critique", "Important", "Secondaire"]
-  - name: modalite
+  - name: id_chronogramme
     type: string
-    required: false
-  - name: phase_exercice
-    type: string
-    required: false
-  - name: observations
-    type: string
-    required: false
-  - name: etablissement_nom
-    type: string
-    required: false
-  - name: etablissement_type
-    type: string
-    required: false
+    required: true
+  - name: numero
+    type: integer
+    required: true
 
 database:
   engine: sqlite

--- a/config/value_mappings.yaml
+++ b/config/value_mappings.yaml
@@ -1,2 +1,13 @@
-type_inject:
-  majeur: Critique
+phase:
+  p1: "1"
+  p2: "2"
+statut:
+  joue: "joué"
+  annule: "annulé"
+type:
+  struct: "structurant"
+  satur: "saturant"
+nature:
+  maille: "mail"
+  sms: "SMS"
+  visio: "vidéo"

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from chronogram_pipeline.src import (
     mapping_utils,
     PipelineLogger,
     enrich_data,
+    apply_schema_columns,
 )
 from chronogram_pipeline.src.logger import get_logger
 
@@ -157,6 +158,9 @@ def run_pipeline(
                 id_chronogramme=chrono_id,
             )
         df_clean.columns = headers
+
+    with plog.step("APPLY_SCHEMA"):
+        df_clean = apply_schema_columns(df_clean, schema_yaml)
 
     with plog.step("STANDARDIZE_VALUES"):
         df_std = standardize_column_values(df_clean, mapping_values, schema_path=schema_yaml)


### PR DESCRIPTION
## Summary
- enforce schema columns with new `schema_utils` module
- generate sequential `numero` and formatted `id_inject` in `enricher`
- apply schema step in pipeline
- update config files with new canonical columns and mappings
- adapt tests to new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c82ffcba883278ba9f1a5ded1739f