### PR TITLE
Fix row cleaning logic and preserve data

### DIFF
--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -114,7 +114,7 @@ def _drop_repeated_rows(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
         values = [
             str(row[c]).strip()
             for c in cols
-            if c in row and not pd.isna(row[c]) and str(row[c]).strip() != ""
+            if c in row.index and pd.notna(row[c]) and str(row[c]).strip() != ""
         ]
         if not values:
             return False
@@ -124,7 +124,10 @@ def _drop_repeated_rows(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
         return max(counts.values()) >= 6
 
     mask = df.apply(is_repeat, axis=1)
-    return df.loc[~mask].reset_index(drop=True)
+    cleaned = df.loc[~mask].reset_index(drop=True)
+    if cleaned.empty and not df.empty:
+        return df.reset_index(drop=True)
+    return cleaned
 
 
 def standardize_and_clean(df: pd.DataFrame, *, chrono_rank: int = 1) -> pd.DataFrame:

--- a/chronogram_pipeline/tests/test_data_cleaner.py
+++ b/chronogram_pipeline/tests/test_data_cleaner.py
@@ -86,3 +86,42 @@ def test_standardize_and_clean_invalid_value():
     out = standardize_and_clean(df)
     assert pd.isna(out["statut"].iloc[0])
 
+
+def test_no_total_line_loss():
+    columns = [
+        "phase",
+        "statut",
+        "type",
+        "horodatage",
+        "emetteur",
+        "recepteur",
+        "nature",
+        "resume",
+        "contenu",
+        "actions_attendues",
+        "commentaires",
+    ]
+
+    df = pd.DataFrame(
+        [
+            ["Texte"] * len(columns),
+            [
+                1,
+                "joué",
+                "structurant",
+                "21/02/2024",
+                "A",
+                "B",
+                "mail",
+                "r",
+                "c",
+                "a",
+                "",
+            ],
+        ],
+        columns=columns,
+    )
+
+    out = clean_data(df)
+    assert not out.empty
+


### PR DESCRIPTION
## Summary
- correct ambiguous condition in `_drop_repeated_rows`
- ensure cleaning step never returns an empty dataframe when input had data
- add regression test to guarantee rows remain after cleaning

## Testing
- `pytest chronogram_pipeline/tests/test_data_cleaner.py::test_no_total_line_loss -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9039e4fc8327b3688eebec977dea