### PR TITLE
Ensure atomic chronogram insertion

### DIFF
--- a/chronogram_pipeline/src/__init__.py
+++ b/chronogram_pipeline/src/__init__.py
@@ -2,6 +2,7 @@ from .db_utils import (
     create_connection,
     init_databases,
     insert_chronogram_metadata,
+    delete_chronogram,
     archive_file,
 )
 from .mapping_utils import (
@@ -47,6 +48,7 @@ __all__ = [
     "clean_data",
     "PipelineLogger",
     "insert_chronogram_metadata",
+    "delete_chronogram",
     "archive_file",
     "enrich_data",
     "apply_schema_columns",

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -209,6 +209,23 @@ def insert_injects(df, db_path: Path | None = None) -> int:
     return len(rows)
 
 
+def delete_chronogram(id_chronogramme: int, db_path: Path | None = None) -> None:
+    """Remove chronogram and related injects from the database."""
+    db_path = db_path or DEFAULT_DB
+    with create_connection(db_path) as conn:
+        init_tables(conn)
+        conn.execute(
+            "DELETE FROM Injects WHERE id_chronogramme = ?",
+            (id_chronogramme,),
+        )
+        conn.execute(
+            "DELETE FROM Chronogrammes WHERE id_chronogramme = ?",
+            (id_chronogramme,),
+        )
+        conn.commit()
+    logger.warning("Deleted chronogram %s with no injects", id_chronogramme)
+
+
 def update_chronogram_stats(id_chronogramme: int, df, db_path: Path | None = None) -> None:
     """Update nb_injects for a chronogram using DataFrame length."""
     import pandas as pd

--- a/chronogram_pipeline/tests/test_pipeline_atomicity.py
+++ b/chronogram_pipeline/tests/test_pipeline_atomicity.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import sqlite3
+from openpyxl import Workbook
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import run_pipeline
+
+
+def test_run_pipeline_skips_empty(tmp_path):
+    xlsx = tmp_path / "empty.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Horodatage", "Description", "Emetteur"])
+    wb.save(xlsx)
+
+    db_path = tmp_path / "db.sqlite"
+    log_dir = tmp_path / "logs"
+
+    with pytest.raises(StopIteration):
+        run_pipeline(xlsx, db_path=db_path, log_dir=log_dir)
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM Chronogrammes")
+        count_chrono = cur.fetchone()[0]
+    assert count_chrono == 0
+

--- a/main.py
+++ b/main.py
@@ -123,50 +123,65 @@ def run_pipeline(
         chrono_id = db_utils.insert_chronogram_metadata(meta_rec, db_path=db_path)
         m["chrono_id"] = chrono_id
 
-    with plog.step("DETECT_SHEET"):
-        sheet_name = excel_parser.detect_main_sheet(xlsx_file)
+    try:
+        with plog.step("DETECT_SHEET"):
+            sheet_name = excel_parser.detect_main_sheet(xlsx_file)
 
-    with plog.step("EXTRACT_RANGE") as m:
-        wb = openpyxl.load_workbook(xlsx_file, data_only=True)
-        sheet = wb[sheet_name]
-        header_row, first_col, last_col = mapping_utils.find_data_table(sheet)
-        df_raw = pd.read_excel(
-            xlsx_file,
-            sheet_name=sheet_name,
-            header=header_row - 1,
-            usecols=range(first_col - 1, last_col),
-        )
-        m["rows"] = len(df_raw)
+        with plog.step("EXTRACT_RANGE") as m:
+            wb = openpyxl.load_workbook(xlsx_file, data_only=True)
+            sheet = wb[sheet_name]
+            header_row, first_col, last_col = mapping_utils.find_data_table(sheet)
+            df_raw = pd.read_excel(
+                xlsx_file,
+                sheet_name=sheet_name,
+                header=header_row - 1,
+                usecols=range(first_col - 1, last_col),
+            )
+            m["rows"] = len(df_raw)
 
-    with plog.step("CLEAN_DATA") as m:
-        df_clean = data_cleaner.clean_data(
-            df_raw,
-            chrono_rank=chrono_id,
-            column_map=column_map,
-            value_map=value_map,
-            columns_file=columns_ref,
-            values_file=values_ref,
-        )
-        m["rows"] = len(df_clean)
+        with plog.step("CLEAN_DATA") as m:
+            df_clean = data_cleaner.clean_data(
+                df_raw,
+                chrono_rank=chrono_id,
+                column_map=column_map,
+                value_map=value_map,
+                columns_file=columns_ref,
+                values_file=values_ref,
+            )
+            m["rows"] = len(df_clean)
 
-    with plog.step("APPLY_SCHEMA"):
-        df_std = apply_schema_columns(df_clean, schema_yaml)
+        with plog.step("APPLY_SCHEMA"):
+            df_std = apply_schema_columns(df_clean, schema_yaml)
 
-    with plog.step("ENRICH_DATA") as m:
-        df_enriched = enrich_data(
-            df_std,
-            id_chronogramme=chrono_id,
-            etablissement_nom=metadata["etablissement_nom"],
-            etablissement_type=metadata["etablissement_type"],
-            nom_chronogramme=metadata["nom_chronogramme"],
-            date_exercice=metadata["date_exercice"],
-        )
-        m["rows"] = len(df_enriched)
+        with plog.step("ENRICH_DATA") as m:
+            df_enriched = enrich_data(
+                df_std,
+                id_chronogramme=chrono_id,
+                etablissement_nom=metadata["etablissement_nom"],
+                etablissement_type=metadata["etablissement_type"],
+                nom_chronogramme=metadata["nom_chronogramme"],
+                date_exercice=metadata["date_exercice"],
+            )
+            m["rows"] = len(df_enriched)
 
-    with plog.step("INSERT_INJECTS") as m:
-        inserted = db_utils.insert_injects(df_enriched, db_path=db_path)
-        db_utils.update_chronogram_stats(chrono_id, df_enriched, db_path=db_path)
-        m["inserted"] = inserted
+        with plog.step("INSERT_INJECTS") as m:
+            inserted = db_utils.insert_injects(df_enriched, db_path=db_path)
+            m["inserted"] = inserted
+            if inserted > 0:
+                db_utils.update_chronogram_stats(
+                    chrono_id, df_enriched, db_path=db_path
+                )
+            else:
+                db_utils.delete_chronogram(chrono_id, db_path=db_path)
+                plog.logger.warning(
+                    "Chronogramme %s rejet\u00e9: aucun inject", xlsx_file.name,
+                    extra={"event": "CHRONO_REJECT", "file": xlsx_file.name},
+                )
+                raise StopIteration("Aucun inject ins\u00e9r\u00e9")
+
+    except Exception:
+        db_utils.delete_chronogram(chrono_id, db_path=db_path)
+        raise
 
     plog.summary()
 


### PR DESCRIPTION
## Summary
- avoid orphan chronograms when inject insertion fails
- warn and remove chronogram entry if no injects were inserted
- expose `delete_chronogram` helper
- test that pipeline skips empty files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9925638c8327bcd33649c87d6781