### PR TITLE
Add additional unit tests for parser and cleaners

### DIFF
--- a/chronogram_pipeline/tests/test_data_cleaner.py
+++ b/chronogram_pipeline/tests/test_data_cleaner.py
@@ -11,6 +11,10 @@ from src.data_cleaner import (
     standardize_and_clean,
     load_column_mapping,
     load_value_mapping,
+    drop_empty_rows,
+    drop_empty_cols,
+    remove_parasitic_rows,
+    _validate_values,
 )
 
 
@@ -182,3 +186,38 @@ def test_clean_data_new_value(tmp_path):
     df_new = pd.read_csv(val_file)
     values = set(df_new.itertuples(index=False, name=None))
     assert ("alpha", "foo", "XXX") in values
+
+
+def test_drop_empty_rows_cols_and_parasitic():
+    df = pd.DataFrame(
+        {
+            "A": ["", None, "data"],
+            "B": [None, None, ""],
+            "C": ["TOTAL", "phase 1", "x"],
+        }
+    )
+    out = drop_empty_rows(df)
+    out = drop_empty_cols(out)
+    out = remove_parasitic_rows(out)
+    assert list(out.columns) == ["A", "C"]
+    assert out.shape[0] == 1
+    assert out.iloc[0]["C"] == "x"
+
+
+def test_validate_values_normalizes(tmp_path):
+    df = pd.DataFrame(
+        {
+            "phase": ["1", "cinq"],
+            "statut": ["Joue", "inval"],
+            "type": ["Structurant", "foo"],
+            "nature": ["SMS", "Oral"],
+            "horodatage": ["01/02/2024 08:00", "bad"],
+        }
+    )
+    _validate_values(df)
+    assert list(df["phase"]) == ["1", pd.NA]
+    assert list(df["statut"]) == ["joué", pd.NA]
+    assert list(df["type"]) == ["structurant", pd.NA]
+    assert list(df["nature"]) == ["SMS", "oral"]
+    assert df["horodatage"].iloc[0] == "2024-02-01T08:00:00"
+    assert pd.isna(df["horodatage"].iloc[1])

--- a/chronogram_pipeline/tests/test_enricher.py
+++ b/chronogram_pipeline/tests/test_enricher.py
@@ -43,3 +43,17 @@ def test_enrich_data_completes_missing_ids(tmp_path):
     assert out["id_inject"].tolist() == ["C002_L001", "C002_L002", "C002_L003", "C002_L004"]
     assert list(out["nb_injects"].unique()) == [4]
 
+
+def test_enrich_data_preserves_input():
+    df = pd.DataFrame({"numero": [5], "Contenu": ["A"]})
+    df_copy = df.copy(deep=True)
+    enrich_data(
+        df,
+        id_chronogramme=3,
+        etablissement_nom="E",
+        etablissement_type="T",
+        nom_chronogramme="N",
+        date_exercice="2024",
+    )
+    assert df.equals(df_copy)
+

--- a/chronogram_pipeline/tests/test_excel_parser.py
+++ b/chronogram_pipeline/tests/test_excel_parser.py
@@ -6,7 +6,7 @@ import openpyxl
 # allow imports from project root
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.excel_parser import detect_main_sheet
+from src.excel_parser import detect_main_sheet, _count_non_empty, _contains_keyword
 
 INPUTS_DIR = Path(__file__).resolve().parents[1] / "data" / "inputs"
 
@@ -26,3 +26,25 @@ def test_detect_main_sheet_tie_returns_first():
     wb = openpyxl.load_workbook(path)
     wb.copy_worksheet(wb.active)
     assert detect_main_sheet(wb) == "Chronogramme "
+
+
+def test_count_non_empty():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "x"
+    ws["C2"] = 42
+    ws["B3"] = ""
+    assert _count_non_empty(ws) == 2
+
+
+def test_contains_keyword_title_and_cells():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Mon Chronogramme"
+    assert _contains_keyword(ws)
+    ws.title = "Feuille"
+    ws["A1"] = "Exercice 2024"
+    assert _contains_keyword(ws)
+    ws.title = "Autre"
+    ws["A1"] = "foo"
+    assert not _contains_keyword(ws)

--- a/chronogram_pipeline/tests/test_standardizer_utils.py
+++ b/chronogram_pipeline/tests/test_standardizer_utils.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+import yaml
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.standardizer import (
+    _load_mapping_normalized,
+    _load_value_mappings,
+    _load_allowed_values,
+)
+
+
+def test_load_mapping_normalized(tmp_path):
+    csv_path = tmp_path / "map.csv"
+    csv_path.write_text(
+        "En-tete original,En-tete standard\nÀ Faire,Action\nstatut,Statut\n",
+        encoding="utf-8",
+    )
+    mapping = _load_mapping_normalized(csv_path)
+    assert mapping["a faire"] == "Action"
+    assert mapping["statut"] == "Statut"
+
+
+def test_load_value_mappings(tmp_path):
+    yaml_path = tmp_path / "vals.yaml"
+    yaml_data = {"statut": {"joué": "OK", "annulé": "KO"}}
+    yaml_path.write_text(yaml.safe_dump(yaml_data, allow_unicode=True), encoding="utf-8")
+    mapping = _load_value_mappings(yaml_path)
+    assert mapping["statut"]["joue"] == "OK"
+    assert mapping["statut"]["annule"] == "KO"
+
+
+def test_load_allowed_values(tmp_path):
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """
+fields:
+  - name: phase
+    values: [1, 2]
+  - name: statut
+    values: [A, B]
+""",
+        encoding="utf-8",
+    )
+    allowed = _load_allowed_values(schema)
+    assert allowed == {"phase": ["1", "2"], "statut": ["A", "B"]}
+


### PR DESCRIPTION
## Summary
- extend excel_parser tests to cover helper functions
- extend data_cleaner tests to check drop helpers and validation
- add tests for standardizer loader helpers
- verify enricher doesn't mutate input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb4ee2a00832788f3c74b544791b6