### PR TITLE
Fix header row detection and add tests

### DIFF
--- a/chronogram_pipeline/src/mapping_utils.py
+++ b/chronogram_pipeline/src/mapping_utils.py
@@ -151,13 +151,53 @@ def detect_main_sheet_openpyxl(workbook_path: Path) -> openpyxl.worksheet.worksh
 
 def find_data_table(sheet: openpyxl.worksheet.worksheet.Worksheet) -> Tuple[int, int, int]:
     """Return header row index and start/end columns of the data table."""
+
+    keywords = {
+        "emetteur",
+        "destinataire",
+        "recepteur",
+        "modalite",
+        "type",
+        "nature",
+        "horodatage",
+        "descriptif",
+        "contenu",
+        "corps",
+        "statut",
+        "phase",
+        "heure",
+        "horaire",
+        "id",
+    }
+
+    def match_keywords(values: Iterable[str]) -> int:
+        norm_values = [normalize_text(v) for v in values]
+        return sum(any(k in val for val in norm_values) for k in keywords)
+
+    # first look for a row containing several known header keywords
+    for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+        values = [cell for cell in row if cell not in (None, "")]
+        if len(values) < 3:
+            continue
+        if match_keywords([str(v) for v in values]) >= 2:
+            first_col = next(i for i, c in enumerate(row, start=1) if c not in (None, ""))
+            last_col = len(row) - next(
+                i for i, c in enumerate(reversed(row), start=1) if c not in (None, "")
+            ) + 1
+            logger.info("Header row detected at line %d", idx)
+            return idx, first_col, last_col
+
+    # fallback to the first row with at least 3 non-empty cells
     for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
         values = [cell for cell in row if cell not in (None, "")]
         if len(values) >= 3:
             first_col = next(i for i, c in enumerate(row, start=1) if c not in (None, ""))
-            last_col = len(row) - next(i for i, c in enumerate(reversed(row), start=1) if c not in (None, "")) + 1
+            last_col = len(row) - next(
+                i for i, c in enumerate(reversed(row), start=1) if c not in (None, "")
+            ) + 1
             logger.info("Header row detected at line %d", idx)
             return idx, first_col, last_col
+
     raise ValueError("No header row found")
 
 

--- a/chronogram_pipeline/tests/test_mapping_utils.py
+++ b/chronogram_pipeline/tests/test_mapping_utils.py
@@ -6,7 +6,11 @@ import pandas as pd
 # allow imports from project root
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.mapping_utils import enrich_mapping_values, update_mapping_headers
+from src.mapping_utils import (
+    enrich_mapping_values,
+    update_mapping_headers,
+    find_data_table,
+)
 
 def test_enrich_mapping_values(tmp_path):
     # Prepare temporary mapping files
@@ -81,3 +85,13 @@ def test_update_mapping_headers(tmp_path):
     assert expected_headers.issubset(headers)
     assert new_added == len(expected_headers) - 1
     assert total >= len(expected_headers)
+
+def test_find_data_table_detects_proper_header():
+    source_file = Path(__file__).resolve().parents[1] / "data" / "inputs" / "chrono test nombreuses colonnes.xlsx"
+    import openpyxl
+    wb = openpyxl.load_workbook(source_file, data_only=True)
+    ws = wb["Chrono GHT"]
+    header_row, first_col, last_col = find_data_table(ws)
+    assert header_row == 3
+    assert first_col == 1
+    assert last_col >= 10


### PR DESCRIPTION
## Summary
- improve `find_data_table` to skip irrelevant rows and look for known keywords
- test header row detection on a sample Excel file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb4c885008327b6bc5e05b824f53a