### PR TITLE
Improve manual mapping workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,17 @@ le service utilisé.
 
 ## Mapping manuel
 
-Le dossier `mapping/` contient les références utilisées par le pipeline :
+- Le dossier `mapping/` contient les références utilisées par le pipeline :
 
-- `colonnes_ref.csv` : fichier à deux colonnes `raw_name` et `mapped_name`. Les
-- nouvelles colonnes détectées sont ajoutées avec `mapped_name` à `XXX`.
-- `valeurs_ref.csv` : fichier à trois colonnes `column_name`, `raw_value` et
-  `mapped_value`. Les nouvelles valeurs sont ajoutées avec `mapped_value` à
-  `XXX`.
+- `colonnes.csv` : colonnes `chronogramme`, `raw_name` et `mapped_name`.
+  Les nouvelles colonnes rencontrées sont ajoutées avec `mapped_name` mis à `X`.
+- `valeurs.csv` : colonnes `chronogramme`, `column_name`, `raw_value` et
+  `mapped_value`. Les valeurs inconnues sont ajoutées avec `mapped_value` à `X`.
 - `colonnes_standardisees.csv` : liste des noms de colonnes cibles possibles.
 - `valeurs_standardisees.csv` : valeurs autorisées pour certaines colonnes.
 
-Après mise à jour de `colonnes_ref.csv` ou `valeurs_ref.csv`, relancez le
-pipeline pour reprendre le traitement.
+Après avoir complété `colonnes.csv` ou `valeurs.csv`, relancez le pipeline pour
+reprendre le traitement.
 
 ## Journaux d'exécution
 

--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 import csv
 
 import pandas as pd
@@ -12,61 +12,118 @@ import pandas as pd
 from .mapping_utils import normalize_text
 
 
-def load_column_mapping(path_ref: Path) -> Dict[str, str]:
-    """Return column name mapping from CSV file at ``path_ref``."""
+def _log_history(path: Path, rows: List[Dict[str, str]]) -> None:
+    """Append mapping history rows to ``path``."""
+    if not rows:
+        return
+    if path.exists():
+        df = pd.read_csv(path)
+    else:
+        df = pd.DataFrame(
+            columns=["timestamp", "chronogramme", "category", "column", "raw", "mapped"]
+        )
+    for row in rows:
+        df.loc[len(df)] = row
+    df.to_csv(path, index=False, quoting=csv.QUOTE_MINIMAL)
+
+
+def load_column_mapping(path_ref: Path, history_file: Path | None = None) -> Dict[str, str]:
+    """Return column name mapping from CSV file at ``path_ref`` and purge applied lines."""
     if not path_ref.exists():
-        pd.DataFrame(columns=["raw_name", "mapped_name"]).to_csv(
+        pd.DataFrame(columns=["chronogramme", "raw_name", "mapped_name"]).to_csv(
             path_ref, index=False, quoting=csv.QUOTE_MINIMAL
         )
         return {}
 
-    df = pd.read_csv(path_ref)
+    df = pd.read_csv(path_ref, dtype=str)
     df.drop_duplicates(subset=["raw_name"], keep="first", inplace=True)
-    df.to_csv(path_ref, index=False, quoting=csv.QUOTE_MINIMAL)
 
     mapping: Dict[str, str] = {}
+    keep_rows = []
+    history: List[Dict[str, str]] = []
     for _, row in df.iterrows():
         raw = row.get("raw_name")
         mapped = row.get("mapped_name")
+        chrono = row.get("chronogramme", "")
         if pd.isna(raw):
             continue
         raw = str(raw)
-        mapped = "" if pd.isna(mapped) else str(mapped)
-        if mapped == "XXX":
-            # waiting for manual association
+        mapped_val = "" if pd.isna(mapped) else str(mapped)
+        if mapped_val == "X":
+            keep_rows.append(row)
             continue
-        if mapped == "":
+        if mapped_val in ("", "__DROP__"):
             mapping[raw] = "__DROP__"
         else:
-            mapping[raw] = mapped
+            mapping[raw] = mapped_val
+        history.append(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "chronogramme": chrono,
+                "category": "column",
+                "column": raw,
+                "raw": raw,
+                "mapped": mapping[raw],
+            }
+        )
+
+    pd.DataFrame(keep_rows, columns=df.columns).to_csv(
+        path_ref, index=False, quoting=csv.QUOTE_MINIMAL
+    )
+    if history_file is not None:
+        _log_history(history_file, history)
+
     return mapping
 
 
-def load_value_mapping(path_ref: Path) -> Dict[str, Dict[str, str]]:
-    """Return per-column value mapping from CSV file at ``path_ref``."""
+def load_value_mapping(path_ref: Path, history_file: Path | None = None) -> Dict[str, Dict[str, str]]:
+    """Return per-column value mapping from CSV and purge applied lines."""
     if not path_ref.exists():
-        pd.DataFrame(columns=["column_name", "raw_value", "mapped_value"]).to_csv(
-            path_ref, index=False, quoting=csv.QUOTE_MINIMAL
-        )
+        pd.DataFrame(
+            columns=["chronogramme", "column_name", "raw_value", "mapped_value"]
+        ).to_csv(path_ref, index=False, quoting=csv.QUOTE_MINIMAL)
         return {}
 
-    df = pd.read_csv(path_ref)
+    df = pd.read_csv(path_ref, dtype=str)
     df.drop_duplicates(subset=["column_name", "raw_value"], keep="first", inplace=True)
-    df.to_csv(path_ref, index=False, quoting=csv.QUOTE_MINIMAL)
 
     mapping: Dict[str, Dict[str, str]] = {}
+    keep_rows = []
+    history: List[Dict[str, str]] = []
     for _, row in df.iterrows():
         col = row.get("column_name")
         raw = row.get("raw_value")
         mapped = row.get("mapped_value")
+        chrono = row.get("chronogramme", "")
         if pd.isna(col) or pd.isna(raw):
             continue
         col = str(col)
         raw = str(raw)
-        mapped = "" if pd.isna(mapped) else str(mapped)
-        if mapped == "XXX":
+        mapped_val = "" if pd.isna(mapped) else str(mapped)
+        if mapped_val == "X":
+            keep_rows.append(row)
             continue
-        mapping.setdefault(col, {})[raw] = mapped
+        if mapped_val == "__EMPTY__" or mapped_val == "":
+            final_val = ""
+        else:
+            final_val = mapped_val
+        mapping.setdefault(col, {})[raw] = final_val
+        history.append(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "chronogramme": chrono,
+                "category": "value",
+                "column": col,
+                "raw": raw,
+                "mapped": final_val,
+            }
+        )
+
+    pd.DataFrame(keep_rows, columns=df.columns).to_csv(
+        path_ref, index=False, quoting=csv.QUOTE_MINIMAL
+    )
+    if history_file is not None:
+        _log_history(history_file, history)
 
     return mapping
 
@@ -129,37 +186,44 @@ def remove_parasitic_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _append_new_columns(path_ref: Path, columns: Iterable[str]) -> None:
-    """Append unknown column names to ``path_ref`` CSV with empty mapping."""
+def _append_new_columns(path_ref: Path, chronogramme: str, columns: Iterable[str]) -> None:
+    """Append unknown column names to ``path_ref`` CSV with placeholder."""
     if path_ref.exists():
-        df = pd.read_csv(path_ref)
+        df = pd.read_csv(path_ref, dtype=str)
     else:
-        df = pd.DataFrame(columns=["raw_name", "mapped_name"])
+        df = pd.DataFrame(columns=["chronogramme", "raw_name", "mapped_name"])
 
     existing = set(df.get("raw_name", []))
     for col in columns:
         if col not in existing:
-            df.loc[len(df)] = {"raw_name": col, "mapped_name": "XXX"}
+            df.loc[len(df)] = {
+                "chronogramme": chronogramme,
+                "raw_name": col,
+                "mapped_name": "X",
+            }
             existing.add(col)
 
     df.drop_duplicates(subset=["raw_name"], keep="first", inplace=True)
     df.to_csv(path_ref, index=False, quoting=csv.QUOTE_MINIMAL)
 
 
-def _append_new_values(path_ref: Path, rows: Iterable[tuple[str, str]]) -> None:
+def _append_new_values(path_ref: Path, chronogramme: str, rows: Iterable[tuple[str, str]]) -> None:
     """Append unknown values to ``path_ref`` CSV with placeholder."""
     if path_ref.exists():
-        df = pd.read_csv(path_ref)
+        df = pd.read_csv(path_ref, dtype=str)
     else:
-        df = pd.DataFrame(columns=["column_name", "raw_value", "mapped_value"])
+        df = pd.DataFrame(
+            columns=["chronogramme", "column_name", "raw_value", "mapped_value"]
+        )
 
     existing = set(zip(df.get("column_name", []), df.get("raw_value", [])))
     for col, val in rows:
         if (col, val) not in existing:
             df.loc[len(df)] = {
+                "chronogramme": chronogramme,
                 "column_name": col,
                 "raw_value": val,
-                "mapped_value": "XXX",
+                "mapped_value": "X",
             }
     df.drop_duplicates(subset=["column_name", "raw_value"], keep="first", inplace=True)
     df.to_csv(path_ref, index=False, quoting=csv.QUOTE_MINIMAL)
@@ -172,13 +236,15 @@ def _apply_mappings(
     *,
     columns_file: Path,
     values_file: Path,
+    chronogramme: str,
+    history_file: Path | None = None,
 ) -> pd.DataFrame:
     """Rename columns and replace values using provided mappings."""
     df = df.copy()
 
     unknown_cols = [c for c in df.columns if c not in column_map]
     if unknown_cols:
-        _append_new_columns(columns_file, unknown_cols)
+        _append_new_columns(columns_file, chronogramme, unknown_cols)
         raise StopIteration("Nouveau nom de colonne à mapper")
 
     rename: Dict[str, str] = {}
@@ -187,8 +253,36 @@ def _apply_mappings(
         mapped = column_map.get(col)
         if mapped == "__DROP__":
             drop_cols.append(col)
+            if history_file is not None:
+                _log_history(
+                    history_file,
+                    [
+                        {
+                            "timestamp": datetime.now().isoformat(),
+                            "chronogramme": chronogramme,
+                            "category": "column",
+                            "column": col,
+                            "raw": col,
+                            "mapped": "__DROP__",
+                        }
+                    ],
+                )
         else:
             rename[col] = mapped
+            if history_file is not None and col != mapped:
+                _log_history(
+                    history_file,
+                    [
+                        {
+                            "timestamp": datetime.now().isoformat(),
+                            "chronogramme": chronogramme,
+                            "category": "column",
+                            "column": col,
+                            "raw": col,
+                            "mapped": mapped,
+                        }
+                    ],
+                )
 
     df = df.rename(columns=rename)
     if drop_cols:
@@ -198,23 +292,42 @@ def _apply_mappings(
         mapping = value_map.get(col)
         if not mapping:
             continue
-        new_vals = []
+        new_vals: List[str] = []
+        used_pairs: List[tuple[str, str]] = []
 
-        def convert(val):
+        def convert(val: object) -> object:
             if pd.isna(val) or str(val).strip() == "":
                 return pd.NA
             raw = str(val)
             if raw not in mapping:
-                new_vals.append(raw)
+                if raw not in new_vals:
+                    new_vals.append(raw)
                 return pd.NA
-            mapped = mapping[raw]
-            return pd.NA if mapped == "" else mapped
+            mapped_val = mapping[raw]
+            used_pairs.append((raw, mapped_val))
+            return "" if mapped_val == "" else mapped_val
 
         df[col] = df[col].map(convert)
 
         if new_vals:
-            _append_new_values(values_file, [(col, v) for v in new_vals])
+            _append_new_values(values_file, chronogramme, [(col, v) for v in new_vals])
             raise StopIteration("Nouvelles valeurs à mapper")
+
+        if history_file is not None and used_pairs:
+            _log_history(
+                history_file,
+                [
+                    {
+                        "timestamp": datetime.now().isoformat(),
+                        "chronogramme": chronogramme,
+                        "category": "value",
+                        "column": col,
+                        "raw": r,
+                        "mapped": m,
+                    }
+                    for r, m in used_pairs
+                ],
+            )
 
     return df
 
@@ -354,6 +467,8 @@ def clean_data(
     value_map: Dict[str, Dict[str, str]] | None = None,
     columns_file: Path | None = None,
     values_file: Path | None = None,
+    chronogramme: str | None = None,
+    history_file: Path | None = None,
 ) -> pd.DataFrame:
     """Return ``df`` cleaned, optionally using manual mappings."""
     df = unmerge_cells(df)
@@ -362,13 +477,20 @@ def clean_data(
     df = remove_parasitic_rows(df)
     df.reset_index(drop=True, inplace=True)
 
-    if column_map is not None and columns_file is not None and values_file is not None:
+    if (
+        column_map is not None
+        and columns_file is not None
+        and values_file is not None
+        and chronogramme is not None
+    ):
         df = _apply_mappings(
             df,
             column_map,
             value_map or {},
             columns_file=columns_file,
             values_file=values_file,
+            chronogramme=chronogramme,
+            history_file=history_file,
         )
 
     df = standardize_and_clean(df, chrono_rank=chrono_rank)

--- a/chronogram_pipeline/tests/test_data_cleaner.py
+++ b/chronogram_pipeline/tests/test_data_cleaner.py
@@ -105,18 +105,32 @@ def test_no_total_line_loss():
 
 # Helpers for mapping tests
 def _create_column_file(path: Path, rows: list[tuple[str, str]]):
-    pd.DataFrame(rows, columns=["raw_name", "mapped_name"]).to_csv(path, index=False)
+    pd.DataFrame(
+        [{"chronogramme": "TEST", "raw_name": r, "mapped_name": m} for r, m in rows],
+        columns=["chronogramme", "raw_name", "mapped_name"],
+    ).to_csv(path, index=False)
 
 
 def _create_value_file(path: Path, rows: list[tuple[str, str, str]]):
-    pd.DataFrame(rows, columns=["column_name", "raw_value", "mapped_value"]).to_csv(path, index=False)
+    pd.DataFrame(
+        [
+            {
+                "chronogramme": "TEST",
+                "column_name": c,
+                "raw_value": r,
+                "mapped_value": m,
+            }
+            for c, r, m in rows
+        ],
+        columns=["chronogramme", "column_name", "raw_value", "mapped_value"],
+    ).to_csv(path, index=False)
 
 
 def test_load_mapping_and_clean(tmp_path):
     col_file = tmp_path / "colonnes.csv"
     val_file = tmp_path / "valeurs.csv"
     _create_column_file(col_file, [("A", "alpha"), ("B", "")])
-    _create_value_file(val_file, [("alpha", "x", "X")])
+    _create_value_file(val_file, [("alpha", "x", "Y")])
 
     col_map = load_column_mapping(col_file)
     val_map = load_value_mapping(val_file)
@@ -129,11 +143,12 @@ def test_load_mapping_and_clean(tmp_path):
         value_map=val_map,
         columns_file=col_file,
         values_file=val_file,
+        chronogramme="TEST",
     )
 
     assert "alpha" in out.columns
     assert "B" not in out.columns
-    assert out["alpha"].iloc[0] == "X"
+    assert out["alpha"].iloc[0] == "Y"
 
 
 def test_clean_data_new_column(tmp_path):
@@ -152,12 +167,13 @@ def test_clean_data_new_column(tmp_path):
             value_map=val_map,
             columns_file=col_file,
             values_file=val_file,
+            chronogramme="TEST",
         )
 
-    # La colonne inconnue doit avoir été ajoutée dans cols.csv avec mapped_name "XXX"
+    # La colonne inconnue doit avoir été ajoutée dans cols.csv avec mapped_name "X"
     df_new = pd.read_csv(col_file)
     assert (df_new["raw_name"] == "Unknown").any()
-    assert (df_new.loc[df_new["raw_name"] == "Unknown", "mapped_name"] == "XXX").any()
+    assert (df_new.loc[df_new["raw_name"] == "Unknown", "mapped_name"] == "X").any()
 
 
 def test_clean_data_new_value(tmp_path):
@@ -176,9 +192,10 @@ def test_clean_data_new_value(tmp_path):
             value_map=val_map,
             columns_file=col_file,
             values_file=val_file,
+            chronogramme="TEST",
         )
 
-    # La nouvelle valeur brute "foo" doit avoir été enregistrée avec "XXX"
+    # La nouvelle valeur brute "foo" doit avoir été enregistrée avec "X"
     df_new = pd.read_csv(val_file)
     values = set(df_new.itertuples(index=False, name=None))
-    assert ("alpha", "foo", "XXX") in values
+    assert ("TEST", "alpha", "foo", "X") in values

--- a/main.py
+++ b/main.py
@@ -80,11 +80,13 @@ def run_pipeline(
     else:
         config_dir = Path(config_dir)
     mapping_dir = Path(__file__).resolve().parent / "mapping"
-    columns_ref = mapping_dir / "colonnes_ref.csv"
-    values_ref = mapping_dir / "valeurs_ref.csv"
+    columns_ref = mapping_dir / "colonnes.csv"
+    values_ref = mapping_dir / "valeurs.csv"
+    history_csv = mapping_dir / "historique_associations.csv"
     schema_yaml = config_dir / "schema_definition.yaml"
-    column_map = data_cleaner.load_column_mapping(columns_ref)
-    value_map = data_cleaner.load_value_mapping(values_ref)
+    column_map = data_cleaner.load_column_mapping(columns_ref, history_file=history_csv)
+    value_map = data_cleaner.load_value_mapping(values_ref, history_file=history_csv)
+    column_map["chronogramme"] = "chronogramme"
 
     if log_dir is not None:
         os.environ["CHRONO_LOG_DIR"] = str(log_dir)
@@ -137,6 +139,7 @@ def run_pipeline(
                 header=header_row - 1,
                 usecols=range(first_col - 1, last_col),
             )
+            df_raw.insert(0, "chronogramme", metadata["nom_chronogramme"])
             m["rows"] = len(df_raw)
 
         with plog.step("CLEAN_DATA") as m:
@@ -147,6 +150,8 @@ def run_pipeline(
                 value_map=value_map,
                 columns_file=columns_ref,
                 values_file=values_ref,
+                chronogramme=metadata["nom_chronogramme"],
+                history_file=history_csv,
             )
             m["rows"] = len(df_clean)
 

--- a/mapping/colonnes.csv
+++ b/mapping/colonnes.csv
@@ -1,0 +1,1 @@
+chronogramme,raw_name,mapped_name

--- a/mapping/historique_associations.csv
+++ b/mapping/historique_associations.csv
@@ -1,0 +1,1 @@
+timestamp,chronogramme,category,column,raw,mapped

--- a/mapping/valeurs.csv
+++ b/mapping/valeurs.csv
@@ -1,0 +1,1 @@
+chronogramme,column_name,raw_value,mapped_value

--- a/tests/test_manual_mapping.py
+++ b/tests/test_manual_mapping.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "chronogram_pipeline"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.data_cleaner import (
+    load_column_mapping,
+    load_value_mapping,
+    _append_new_columns,
+    _append_new_values,
+)
+
+
+def test_load_column_mapping_purge(tmp_path):
+    csv = tmp_path / "colonnes.csv"
+    pd.DataFrame(
+        [
+            {"chronogramme": "C1", "raw_name": "A", "mapped_name": "X"},
+            {"chronogramme": "C1", "raw_name": "B", "mapped_name": "phase"},
+            {"chronogramme": "C1", "raw_name": "C", "mapped_name": ""},
+        ]
+    ).to_csv(csv, index=False)
+    history = tmp_path / "hist.csv"
+    mapping = load_column_mapping(csv, history_file=history)
+    assert mapping == {"B": "phase", "C": "__DROP__"}
+    remaining = pd.read_csv(csv)
+    assert list(remaining["raw_name"]) == ["A"]
+    hist = pd.read_csv(history)
+    assert len(hist) == 2
+
+
+def test_load_value_mapping_purge(tmp_path):
+    csv = tmp_path / "valeurs.csv"
+    pd.DataFrame(
+        [
+            {
+                "chronogramme": "C1",
+                "column_name": "phase",
+                "raw_value": "X",
+                "mapped_value": "1",
+            },
+            {
+                "chronogramme": "C1",
+                "column_name": "statut",
+                "raw_value": "old",
+                "mapped_value": "X",
+            },
+            {
+                "chronogramme": "C1",
+                "column_name": "phase",
+                "raw_value": "y",
+                "mapped_value": "__EMPTY__",
+            },
+        ]
+    ).to_csv(csv, index=False)
+    history = tmp_path / "hist_val.csv"
+    mapping = load_value_mapping(csv, history_file=history)
+    assert mapping == {"phase": {"X": "1", "y": ""}}
+    remaining = pd.read_csv(csv)
+    assert len(remaining) == 1
+    assert remaining.iloc[0]["raw_value"] == "old"
+    hist = pd.read_csv(history)
+    assert len(hist) == 2
+
+
+def test_append_functions_no_duplicates(tmp_path):
+    col_csv = tmp_path / "cols.csv"
+    _append_new_columns(col_csv, "C1", ["A", "B"])
+    _append_new_columns(col_csv, "C2", ["A", "C"])
+    df = pd.read_csv(col_csv)
+    assert set(df["raw_name"]) == {"A", "B", "C"}
+
+    val_csv = tmp_path / "vals.csv"
+    _append_new_values(val_csv, "C1", [("col", "1"), ("col", "2")])
+    _append_new_values(val_csv, "C2", [("col", "1")])
+    dfv = pd.read_csv(val_csv)
+    assert len(dfv) == 2


### PR DESCRIPTION
## Summary
- overhaul mapping utilities for `colonnes.csv` and `valeurs.csv`
- store mapping history in `mapping/historique_associations.csv`
- load mappings in `main.py` and add a `chronogramme` column to raw data
- update tests and add coverage for manual mapping helpers
- document new mapping files in `README.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb3ee62f483278d84c8af7a635a48