### PR TITLE
Fix imports and expose cleaning utilities

### DIFF
--- a/chronogram_pipeline/src/data_cleaner.py
+++ b/chronogram_pipeline/src/data_cleaner.py
@@ -224,3 +224,210 @@ def _apply_mappings(
             raise StopIteration("Nouvelles valeurs à mapper")
 
     return df
+
+
+def unmerge_cells(df: pd.DataFrame) -> pd.DataFrame:
+    """Propagate merged cell values vertically and horizontally."""
+    result = df.copy()
+    result = result.ffill()
+    if isinstance(result, pd.Series):
+        result = result.to_frame().T
+    result = result.ffill(axis=1)
+    return result
+
+
+def drop_empty_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove rows that are completely empty or contain only blanks."""
+    df = df.copy()
+    df.replace(r"^\s*$", pd.NA, regex=True, inplace=True)
+    df.dropna(axis=0, how="all", inplace=True)
+    return df
+
+
+def drop_empty_cols(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove columns that contain no data below the header row."""
+    df = df.copy()
+    df.replace(r"^\s*$", pd.NA, regex=True, inplace=True)
+    data = df.iloc[1:] if len(df) > 1 else df
+    empty = [col for col in df.columns if data[col].isna().all()]
+    df.drop(columns=empty, inplace=True)
+    return df
+
+
+def remove_parasitic_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows like 'TOTAL' or 'Phase X' that do not contain data."""
+    df = df.copy()
+    keywords = ("total", "phase")
+
+    def is_parasitic(row) -> bool:
+        cells = [
+            str(c).strip().lower()
+            for c in row
+            if not pd.isna(c) and str(c).strip() != ""
+        ]
+        if len(cells) == 1:
+            val = cells[0]
+            return any(val.startswith(k) for k in keywords)
+        return False
+
+    mask = df.apply(is_parasitic, axis=1)
+    df = df[~mask]
+    return df
+
+
+def _validate_values(df: pd.DataFrame) -> None:
+    """Normalize and validate values for specific columns."""
+
+    allowed = {
+        "phase": {"1": "1", "2": "2", "3": "3", "4": "4"},
+        "statut": {"joue": "joué", "annule": "annulé", "a jouer": "à jouer"},
+        "type": {"structurant": "structurant", "saturant": "saturant"},
+        "nature": {
+            "mail": "mail",
+            "appel": "appel",
+            "sms": "SMS",
+            "video": "vidéo",
+            "weezer": "Weezer",
+            "oral": "oral",
+        },
+    }
+
+    for col, mapping in allowed.items():
+        if col not in df.columns:
+            continue
+
+        def convert(val):
+            if pd.isna(val) or str(val).strip() == "":
+                return pd.NA
+            key = normalize_text(val)
+            return mapping.get(key, pd.NA)
+
+        df[col] = df[col].map(convert)
+
+    if "horodatage" in df.columns:
+        def parse_ts(val):
+            if pd.isna(val) or str(val).strip() == "":
+                return pd.NA
+            ts = pd.to_datetime(str(val), dayfirst=True, errors="coerce")
+            if pd.isna(ts):
+                return pd.NA
+            return ts.strftime("%Y-%m-%dT%H:%M:%S")
+
+        df["horodatage"] = df["horodatage"].map(parse_ts)
+
+
+def _drop_repeated_rows(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """Remove rows where the same value appears in >=6 columns."""
+
+    def is_repeat(row: pd.Series) -> bool:
+        values = [
+            str(row[c]).strip()
+            for c in cols
+            if c in row.index and pd.notna(row[c]) and str(row[c]).strip() != ""
+        ]
+        if not values:
+            return False
+        counts: Dict[str, int] = {}
+        for v in values:
+            counts[v] = counts.get(v, 0) + 1
+        return max(counts.values()) >= 6
+
+    mask = df.apply(is_repeat, axis=1)
+    cleaned = df.loc[~mask].reset_index(drop=True)
+    if cleaned.empty and not df.empty:
+        return df.reset_index(drop=True)
+    return cleaned
+
+
+def standardize_and_clean(df: pd.DataFrame, *, chrono_rank: int = 1) -> pd.DataFrame:
+    """Standardize columns and add identifier columns."""
+
+    mapping = {
+        "phase": "phase",
+        "statut inject": "statut",
+        "statut": "statut",
+        "type": "type",
+        "horodatage": "horodatage",
+        "emetteur": "emetteur",
+        "emmeteur": "emetteur",
+        "destinataire": "recepteur",
+        "recepteur": "recepteur",
+        "nature": "nature",
+        "descriptif": "resume",
+        "description": "resume",
+        "resume": "resume",
+        "corps": "contenu",
+        "contenu": "contenu",
+        "actions attendues": "actions_attendues",
+        "reactions attendues": "actions_attendues",
+        "commentaires": "commentaires",
+        "observations": "commentaires",
+    }
+
+    std_cols = [
+        "phase",
+        "statut",
+        "type",
+        "horodatage",
+        "emetteur",
+        "recepteur",
+        "nature",
+        "resume",
+        "contenu",
+        "actions_attendues",
+        "commentaires",
+    ]
+
+    rename: Dict[str, str] = {}
+    for col in list(df.columns):
+        norm = normalize_text(col)
+        if norm in mapping:
+            rename[col] = mapping[norm]
+
+    data = df.rename(columns=rename)
+    for col in std_cols:
+        if col not in data.columns:
+            data[col] = pd.NA
+
+    data = _drop_repeated_rows(data, std_cols)
+    _validate_values(data)
+
+    chrono_id = f"C{chrono_rank:03d}"
+    numeros = [f"L{i:03d}" for i in range(1, len(data) + 1)]
+    data.insert(0, "id_chronogramme", chrono_id)
+    data.insert(1, "numero", numeros)
+    data.insert(2, "id_inject", [f"{chrono_id}_{n}" for n in numeros])
+    data.replace({pd.NA: None}, inplace=True)
+
+    return data
+
+
+def clean_data(
+    df: pd.DataFrame,
+    *,
+    chrono_rank: int = 1,
+    column_map: Dict[str, str] | None = None,
+    value_map: Dict[str, Dict[str, str]] | None = None,
+    columns_file: Path | None = None,
+    values_file: Path | None = None,
+    chrono_name: str | None = None,
+) -> pd.DataFrame:
+    """Return ``df`` cleaned, optionally using manual mappings."""
+    df = unmerge_cells(df)
+    df = drop_empty_rows(df)
+    df = drop_empty_cols(df)
+    df = remove_parasitic_rows(df)
+    df.reset_index(drop=True, inplace=True)
+
+    if column_map is not None and columns_file is not None and values_file is not None:
+        df = _apply_mappings(
+            df,
+            column_map,
+            value_map or {},
+            columns_file=columns_file,
+            values_file=values_file,
+            chrono_name=chrono_name,
+        )
+
+    df = standardize_and_clean(df, chrono_rank=chrono_rank)
+    return df

--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ from typing import Dict, Iterable
 
 import pandas as pd
 
-from .mapping_utils import normalize_text
+from chronogram_pipeline.src.mapping_utils import normalize_text
+from chronogram_pipeline.src.excel_parser import detect_main_sheet
+from chronogram_pipeline.src.data_cleaner import clean_data
+from chronogram_pipeline.src.db_utils import create_connection, init_tables
+from chronogram_pipeline.src.db_utils import DEFAULT_DB
+from chronogram_pipeline.src.logger import get_logger
 
 
 def _norm(value: str) -> str:
@@ -410,3 +415,31 @@ def clean_data(
 
     df = standardize_and_clean(df, chrono_rank=chrono_rank)
     return df
+
+
+def run_pipeline(
+    excel_path: Path | str,
+    *,
+    db_path: Path | str | None = None,
+    log_dir: Path | str | None = None,
+) -> dict:
+    """Minimal pipeline used for testing.
+
+    Initializes the SQLite database, loads the Excel file and
+    returns the cleaned DataFrame. A ``StopIteration`` is raised
+    when the file does not contain any data rows.
+    """
+
+    db = Path(db_path) if db_path is not None else DEFAULT_DB
+    with create_connection(db) as conn:
+        init_tables(conn)
+
+    excel_path = Path(excel_path)
+    sheet = detect_main_sheet(excel_path)
+    df = pd.read_excel(excel_path, sheet_name=sheet)
+
+    if df.dropna(how="all").shape[0] <= 1:
+        raise StopIteration("Empty chronogram")
+
+    cleaned = clean_data(df)
+    return {"df": df, "clean_df": cleaned}


### PR DESCRIPTION
## Summary
- expose data cleaning utilities in `src.data_cleaner`
- make `main.py` importable and add a minimal `run_pipeline`
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb87c6a388327b95b03eafbe80031