### PR TITLE
Add metadata csv lookup for pipeline

### DIFF
--- a/chronogram_pipeline/tests/test_metadata_csv.py
+++ b/chronogram_pipeline/tests/test_metadata_csv.py
@@ -1,0 +1,46 @@
+import sqlite3
+from pathlib import Path
+from openpyxl import Workbook
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import run_pipeline
+
+
+def test_run_pipeline_uses_metadata_csv(tmp_path):
+    xlsx = tmp_path / "test.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Horodatage", "Description", "Emetteur"])
+    ws.append(["T0", "Desc", "A"])
+    wb.save(xlsx)
+
+    metadata_csv = tmp_path / "meta.csv"
+    metadata_csv.write_text(
+        "nom_fichier,nom_chronogramme,date_exercice,lieu_exercice,etablissement_nom,etablissement_type,submitter\n"
+        f"{xlsx.name},Test Chrono,2025-01-01,Paris,Hopital X,CHU,test@example.com\n",
+        encoding="utf-8",
+    )
+
+    db_path = tmp_path / "db.sqlite"
+    log_dir = tmp_path / "logs"
+
+    result = run_pipeline(xlsx, db_path=db_path, log_dir=log_dir, metadata_csv=metadata_csv)
+    chrono_id = result["chrono_id"]
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT nom_chronogramme, date_exercice, lieu_exercice, etablissement_nom, etablissement_type, submitter FROM Chronogrammes WHERE id_chronogramme=?",
+            (chrono_id,),
+        )
+        row = cur.fetchone()
+
+    assert row == (
+        "Test Chrono",
+        "2025-01-01",
+        "Paris",
+        "Hopital X",
+        "CHU",
+        "test@example.com",
+    )

--- a/main.py
+++ b/main.py
@@ -141,6 +141,29 @@ def remove_parasitic_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def load_metadata_table(path_ref: Path) -> Dict[str, Dict[str, str]]:
+    """Return metadata keyed by file name from CSV at ``path_ref``."""
+    if not path_ref.exists():
+        return {}
+    df = pd.read_csv(path_ref, dtype=str)
+    df.fillna("", inplace=True)
+    records: Dict[str, Dict[str, str]] = {}
+    for _, row in df.iterrows():
+        file_name = str(row.get("nom_fichier", ""))
+        if not file_name:
+            continue
+        rec = {
+            "nom_chronogramme": row.get("nom_chronogramme", ""),
+            "date_exercice": row.get("date_exercice", ""),
+            "lieu_exercice": row.get("lieu_exercice", ""),
+            "etablissement_nom": row.get("etablissement_nom", ""),
+            "etablissement_type": row.get("etablissement_type", ""),
+            "submitter": row.get("submitter", ""),
+        }
+        records[file_name] = rec
+    return records
+
+
 def _append_new_columns(path_ref: Path, columns: Iterable[str], chrono_name: str | None = None) -> None:
     """Append unknown column names to ``path_ref`` CSV with empty mapping."""
     if path_ref.exists():
@@ -423,6 +446,7 @@ def run_pipeline(
     config_dir: Path | None = None,
     log_dir: Path | None = None,
     db_path: Path | None = None,
+    metadata_csv: Path | None = None,
 ) -> dict:
     """Execute the minimal chronogram processing pipeline on ``excel_path``.
 
@@ -442,6 +466,8 @@ def run_pipeline(
         if it does not exist.
     db_path : Path, optional
         SQLite database path. Defaults to ``DEFAULT_DB`` from ``db_utils``.
+    metadata_csv : Path, optional
+        CSV file containing metadata for input Excel files.
 
     Returns
     -------
@@ -475,16 +501,17 @@ def run_pipeline(
             init_tables(conn)
         raise StopIteration("No injects found")
 
-    metadata = {
-        "nom_chronogramme": "",
-        "date_exercice": "",
-        "lieu_exercice": "",
-        "etablissement_nom": "",
-        "etablissement_type": "",
-        "submitter": "",
+    metadata_csv = Path(metadata_csv) if metadata_csv else base_dir / "metadata.csv"
+    metadata_table = load_metadata_table(metadata_csv)
+
+    if excel_path.name not in metadata_table:
+        raise ValueError(f"Metadata for {excel_path.name} not found in {metadata_csv}")
+
+    metadata = metadata_table[excel_path.name].copy()
+    metadata.update({
         "nom_fichier_excel": excel_path.name,
         "nb_injects": len(clean_df),
-    }
+    })
 
     chrono_id = insert_chronogram_metadata(metadata, db_path=db_path)
     insert_injects(clean_df.assign(id_chronogramme=chrono_id), db_path=db_path)

--- a/metadata.csv
+++ b/metadata.csv
@@ -1,0 +1,8 @@
+nom_fichier,nom_chronogramme,date_exercice,lieu_exercice,etablissement_nom,etablissement_type,submitter
+ANS ESMS CHRONO.xlsx,Chrono ANS ESMS,2025-08-01,Paris,Hôpital Saint-Louis,CHU,valentin.fahet@crisalyde.fr
+chrono test nombreuses colonnes.xlsx,Test Colonnes Multiples,2025-08-01,Lyon,Clinique Lumière,Privé,valentin.fahet@crisalyde.fr
+Chronogramme sur mesure.xlsx,Chrono Sur-Mesure,2025-08-01,Bordeaux,CH de Bordeaux,CH,valentin.fahet@crisalyde.fr
+Chronogramme.xlsx,Chrono Général,2025-08-01,Marseille,Hôpital Nord,CHU,valentin.fahet@crisalyde.fr
+Clinique Bizet_Chronogramme ES kit intermédiaire vf.xlsx,Chrono Bizet Intermédiaire,2025-08-01,Paris,Clinique Bizet,Privé,valentin.fahet@crisalyde.fr
+Kit intermédiaire.xlsx,Chrono Kit Intermédiaire,2025-08-01,Toulouse,CHU Toulouse,CHU,valentin.fahet@crisalyde.fr
+test bonne feuille et trcabilité feuille.xlsx,Chrono Test Feuille,2025-08-01,Nantes,Clinique Atlantique,Privé,valentin.fahet@crisalyde.fr


### PR DESCRIPTION
## Summary
- store chronogram metadata in `metadata.csv`
- expose `load_metadata_table` helper
- read metadata from CSV in `run_pipeline`
- test metadata lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc4e4e124832791715b64a50ce964