### PR TITLE
Add csv_to_dict tests and handle empty CSV

### DIFF
--- a/chronogram_pipeline/src/correction_tool.py
+++ b/chronogram_pipeline/src/correction_tool.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import Dict
 
+from pandas.errors import EmptyDataError
+
 import pandas as pd
 
 from .logger import get_logger
@@ -25,7 +27,11 @@ def csv_to_dict(csv_path: Path) -> Dict[str, str]:
         Dictionnaire ``{cle: valeur}`` généré à partir des colonnes du fichier.
     """
     logger.debug("Reading CSV corrections from %s", csv_path)
-    df = pd.read_csv(csv_path, header=None)
+    try:
+        df = pd.read_csv(csv_path, header=None)
+    except EmptyDataError:
+        logger.warning("Empty or invalid CSV file %s", csv_path)
+        return {}
     if df.empty or df.shape[1] < 2:
         logger.warning("Empty or invalid CSV file %s", csv_path)
         return {}

--- a/chronogram_pipeline/tests/test_correction_tool.py
+++ b/chronogram_pipeline/tests/test_correction_tool.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.correction_tool import csv_to_dict
+
+
+def test_csv_to_dict_basic(tmp_path):
+    data = pd.DataFrame([["A", "Alpha"], ["B", "Beta"]])
+    csv_file = tmp_path / "map.csv"
+    data.to_csv(csv_file, index=False, header=False)
+
+    result = csv_to_dict(csv_file)
+
+    assert result == {"A": "Alpha", "B": "Beta"}
+
+
+def test_csv_to_dict_empty_or_single(tmp_path):
+    empty_file = tmp_path / "empty.csv"
+    pd.DataFrame().to_csv(empty_file, index=False, header=False)
+    single_col_file = tmp_path / "single.csv"
+    pd.DataFrame([["A"], ["B"]]).to_csv(single_col_file, index=False, header=False)
+
+    assert csv_to_dict(empty_file) == {}
+    assert csv_to_dict(single_col_file) == {}


### PR DESCRIPTION
## Summary
- add new tests for csv_to_dict to cover normal and empty/single-column cases
- handle `EmptyDataError` in `csv_to_dict`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc9bc6b40832780e0a2688e2aa7c9