### PR TITLE
Change chrono ID format & drop global inject id

### DIFF
--- a/Specifications_techniques.md
+++ b/Specifications_techniques.md
@@ -676,8 +676,8 @@ Cette table contient une **ligne par exercice de crise** (chronogramme)
 intégré. Elle regroupe les informations générales issues du formulaire
 ainsi que quelques champs d'administration. Schéma proposé :
 
--   **id_chronogramme** -- *INTEGER, PRIMARY KEY* (auto-incrément en
-    SQLite). Identifiant unique du chronogramme/exercice. Sera utilisé
+-   **id_chronogramme** -- *TEXT, PRIMARY KEY*. Identifiant unique du
+    chronogramme/exercice (ex. `C001`). Sera utilisé
     comme référence étrangère dans la table des injects.
 -   **nom_chronogramme** -- *TEXT, NOT NULL*. Nom ou titre de l'exercice
     de crise. Par exemple *« Exercice Inondation Paris 2023 »*.
@@ -739,11 +739,7 @@ chronogrammes intégrés, avec leurs attributs standardisés. Chaque ligne
 correspond à un événement simulé dans un exercice. Schéma générique (à
 adapter selon les champs observés dans les chronogrammes) :
 
--   **id_inject_global** -- *INTEGER, PRIMARY KEY*. Identifiant
-    technique unique de l'inject au niveau global (peut être
-    auto-incrémental indépendamment de l'exercice, ou calculé). Ce champ
-    sert de surrogate key purement interne.
--   **id_chronogramme** -- *INTEGER, FOREIGN KEY*, **NOT NULL**.
+-   **id_chronogramme** -- *TEXT, PRIMARY KEY*, **NOT NULL**.
     Référence vers l'exercice parent (l'ID dans la table Chronogrammes).
     Assure le lien de chaque inject à son chronogramme. Idéalement, une
     contrainte FOREIGN KEY (bien que SQLite ne les enforce que si
@@ -813,10 +809,9 @@ présentes dans tous les chronogrammes. L'objectif est d'avoir un schéma
 injects. Toute colonne non reconnue dans un fichier sera ignorée à
 l'intégration (sauf si on décide d'étendre le schéma pour l'inclure).
 
-**Contraintes** : La clé primaire est `id_inject_global`. On définit en
-outre une **clé étrangère** `id_chronogramme` référant
+**Contraintes** : On définit une **clé étrangère** `id_chronogramme` référant
 `Chronogrammes(id_chronogramme)` pour garantir l'intégrité référentielle
-(SQLite le permet). On met en place une **clé unique composite** sur
+(SQLite le permet). Une **clé unique composite** est mise sur
 (`id_chronogramme`, `id_inject`) afin d'éviter d'insérer deux fois le
 même inject du même exercice, et pouvoir repérer d'éventuels doublons.
 Cela signifie qu'on ne pourra pas avoir deux lignes avec le même numéro

--- a/chronogram_pipeline/src/db_utils.py
+++ b/chronogram_pipeline/src/db_utils.py
@@ -16,7 +16,7 @@ DEFAULT_DB = DB_DIR / "chronogrammes.db"
 
 CHRONO_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS Chronogrammes (
-    id_chronogramme INTEGER PRIMARY KEY,
+    id_chronogramme TEXT PRIMARY KEY,
     nom_chronogramme TEXT NOT NULL,
     date_exercice TEXT,
     lieu_exercice TEXT,
@@ -31,8 +31,7 @@ CREATE TABLE IF NOT EXISTS Chronogrammes (
 
 INJECTS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS Injects (
-    id_inject_global INTEGER PRIMARY KEY,
-    id_chronogramme INTEGER NOT NULL,
+    id_chronogramme TEXT NOT NULL,
     id_inject TEXT,
     horodatage TEXT,
     description TEXT,
@@ -49,12 +48,14 @@ CREATE TABLE IF NOT EXISTS Injects (
 );
 """
 
+
 def create_connection(db_path: Path) -> sqlite3.Connection:
     """Create a SQLite connection enabling foreign keys."""
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
+
 
 def init_tables(conn: sqlite3.Connection) -> None:
     """Create Chronogrammes and Injects tables."""
@@ -76,12 +77,23 @@ def init_databases(chronogram_db: Path, injects_db: Path) -> None:
     logger.info("Databases initialised: %s, %s", chronogram_db, injects_db)
 
 
-def insert_chronogram(record: Dict[str, Any], db_path: Path | None = None) -> int:
+def insert_chronogram(record: Dict[str, Any], db_path: Path | None = None) -> str:
     """Insert a chronogram record and return its generated ID."""
     db_path = db_path or DEFAULT_DB
     with create_connection(db_path) as conn:
         init_tables(conn)
+        cur = conn.execute("SELECT id_chronogramme FROM Chronogrammes")
+        ids = [row[0] for row in cur.fetchall()]
+        next_num = (
+            max(
+                (int(i[1:]) for i in ids if isinstance(i, str) and i[1:].isdigit()),
+                default=0,
+            )
+            + 1
+        )
+        chrono_id = f"C{next_num:03d}"
         columns = [
+            "id_chronogramme",
             "nom_chronogramme",
             "date_exercice",
             "lieu_exercice",
@@ -92,12 +104,24 @@ def insert_chronogram(record: Dict[str, Any], db_path: Path | None = None) -> in
             "fichier_source",
             "nb_injects",
         ]
-        values = [record.get(col) for col in columns]
+        values = [
+            chrono_id,
+            record.get("nom_chronogramme"),
+            record.get("date_exercice"),
+            record.get("lieu_exercice"),
+            record.get("etablissement_nom"),
+            record.get("etablissement_type"),
+            record.get("submitter"),
+            record.get("date_soumission"),
+            record.get("fichier_source"),
+            record.get("nb_injects"),
+        ]
         placeholders = ", ".join("?" for _ in columns)
-        sql = f"INSERT INTO Chronogrammes ({', '.join(columns)}) VALUES ({placeholders})"
-        cur = conn.execute(sql, values)
+        sql = (
+            f"INSERT INTO Chronogrammes ({', '.join(columns)}) VALUES ({placeholders})"
+        )
+        conn.execute(sql, values)
         conn.commit()
-        chrono_id = int(cur.lastrowid)
         logger.debug("Inserted chronogram with id %s", chrono_id)
         return chrono_id
 
@@ -123,7 +147,9 @@ def _format_date(value: Any) -> str:
     return _clean_string(value)
 
 
-def insert_chronogram_metadata(metadata: Dict[str, Any], db_path: Path | None = None) -> int:
+def insert_chronogram_metadata(
+    metadata: Dict[str, Any], db_path: Path | None = None
+) -> str:
     """Validate, clean and insert chronogram metadata.
 
     Parameters
@@ -135,7 +161,7 @@ def insert_chronogram_metadata(metadata: Dict[str, Any], db_path: Path | None = 
 
     Returns
     -------
-    int
+    str
         The generated ``id_chronogramme``.
     """
 
@@ -209,7 +235,7 @@ def insert_injects(df, db_path: Path | None = None) -> int:
     return len(rows)
 
 
-def delete_chronogram(id_chronogramme: int, db_path: Path | None = None) -> None:
+def delete_chronogram(id_chronogramme: str, db_path: Path | None = None) -> None:
     """Remove chronogram and related injects from the database."""
     db_path = db_path or DEFAULT_DB
     with create_connection(db_path) as conn:
@@ -226,7 +252,9 @@ def delete_chronogram(id_chronogramme: int, db_path: Path | None = None) -> None
     logger.warning("Deleted chronogram %s with no injects", id_chronogramme)
 
 
-def update_chronogram_stats(id_chronogramme: int, df, db_path: Path | None = None) -> None:
+def update_chronogram_stats(
+    id_chronogramme: str, df, db_path: Path | None = None
+) -> None:
     """Update nb_injects for a chronogram using DataFrame length."""
     import pandas as pd
 
@@ -248,7 +276,7 @@ def update_chronogram_stats(id_chronogramme: int, df, db_path: Path | None = Non
 def archive_file(
     file_path: Path,
     *,
-    chrono_id: int | None = None,
+    chrono_id: str | None = None,
     archive_dir: Path | None = None,
 ) -> Path:
     """Move ``file_path`` to the archive directory with a timestamped name.
@@ -257,7 +285,7 @@ def archive_file(
     ----------
     file_path : Path
         Excel file that has been successfully processed.
-    chrono_id : int, optional
+    chrono_id : str, optional
         Chronogram identifier used to build the archive filename.
     archive_dir : Path, optional
         Destination directory. Defaults to ``data/archive/raw_excels`` in the
@@ -284,4 +312,3 @@ def archive_file(
     shutil.move(str(file_path), dest)
     logger.info("Archived %s to %s", file_path, dest)
     return dest
-

--- a/chronogram_pipeline/src/enricher.py
+++ b/chronogram_pipeline/src/enricher.py
@@ -10,7 +10,7 @@ logger = get_logger(__name__)
 def enrich_data(
     df: pd.DataFrame,
     *,
-    id_chronogramme: int,
+    id_chronogramme: str,
     etablissement_nom: str,
     etablissement_type: str,
     nom_chronogramme: str,
@@ -22,7 +22,7 @@ def enrich_data(
     ----------
     df : DataFrame
         Clean and standardised table of injects.
-    id_chronogramme : int
+    id_chronogramme : str
         Identifier of the parent chronogram.
     etablissement_nom : str
         Establishment name.
@@ -49,7 +49,7 @@ def enrich_data(
 
     # sequential numbering and unique inject identifier
     data["numero"] = list(range(1, len(data) + 1))
-    data["id_inject"] = [f"C{id_chronogramme:03d}_L{num:03d}" for num in data["numero"]]
+    data["id_inject"] = [f"{id_chronogramme}_L{num:03d}" for num in data["numero"]]
     logger.info("numero generated", extra={"event": "AUTO_NUM"})
 
     data["nb_injects"] = len(data)

--- a/chronogram_pipeline/src/standardizer.py
+++ b/chronogram_pipeline/src/standardizer.py
@@ -17,7 +17,9 @@ from .mapping_utils import normalize_text
 logger = get_logger(__name__)
 
 # Default path for the mappings log file
-CONTROL_DIR = Path(os.getenv("CHRONO_LOG_DIR", Path(__file__).resolve().parents[1] / "data/control"))
+CONTROL_DIR = Path(
+    os.getenv("CHRONO_LOG_DIR", Path(__file__).resolve().parents[1] / "data/control")
+)
 DEFAULT_MAPPING_LOG = CONTROL_DIR / "mappings_log.xlsx"
 
 # Type of the callback used to suggest a header
@@ -53,7 +55,9 @@ def _load_mapping_normalized(mapping_csv: Path) -> Dict[str, str]:
 
 def _save_mapping(mapping_csv: Path, mapping: Mapping[str, str]) -> None:
     """Write header ``mapping`` to ``mapping_csv`` in UTF-8."""
-    df = pd.DataFrame(list(mapping.items()), columns=["En-tête original", "En-tête standard"])
+    df = pd.DataFrame(
+        list(mapping.items()), columns=["En-tête original", "En-tête standard"]
+    )
     mapping_csv.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(mapping_csv, index=False, encoding="utf-8", quoting=csv.QUOTE_MINIMAL)
 
@@ -71,7 +75,7 @@ def _append_mapping_log(
     rows: Iterable[tuple[str, str, str]],
     log_path: Path,
     *,
-    chrono_id: int | None = None,
+    chrono_id: str | None = None,
 ) -> None:
     """Append mapping *rows* to *log_path* with optional chronogram id."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -119,7 +123,12 @@ def _default_mistral_call(header: str, allowed: Iterable[str]) -> str:
         "model": "mistral-small",
         "messages": [{"role": "user", "content": prompt}],
     }
-    resp = requests.post("https://api.mistral.ai/v1/chat/completions", headers=headers, json=payload, timeout=30)
+    resp = requests.post(
+        "https://api.mistral.ai/v1/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=30,
+    )
     resp.raise_for_status()
     data = resp.json()
     return data["choices"][0]["message"]["content"].strip()
@@ -130,7 +139,7 @@ def standardize_headers_rules(
     *,
     mapping_csv: Path,
     log_xlsx: Path | None = None,
-    id_chronogramme: int | None = None,
+    id_chronogramme: str | None = None,
 ) -> List[str]:
     """Standardize headers using only local dictionary rules."""
     mapping = _load_mapping_normalized(mapping_csv)
@@ -165,7 +174,7 @@ def standardize_headers(
     gpt_suggest_header: SuggestFunc | None = None,
     file_name: str | None = None,
     log_xlsx: Path | None = None,
-    id_chronogramme: int | None = None,
+    id_chronogramme: str | None = None,
 ) -> List[str]:
     """Return list of standardized headers using dictionary and optional AI."""
     mapping = _load_mapping(mapping_csv)
@@ -232,11 +241,15 @@ def _load_value_mappings(yaml_path: Path) -> Dict[str, Dict[str, str]]:
     data = yaml.safe_load(yaml_path.read_text()) or {}
     mappings: Dict[str, Dict[str, str]] = {}
     for col, vals in data.items():
-        mappings[col] = {normalize_text(str(k)): str(v) for k, v in (vals or {}).items()}
+        mappings[col] = {
+            normalize_text(str(k)): str(v) for k, v in (vals or {}).items()
+        }
     return mappings
 
 
-def _save_value_mappings(yaml_path: Path, mappings: Mapping[str, Mapping[str, str]]) -> None:
+def _save_value_mappings(
+    yaml_path: Path, mappings: Mapping[str, Mapping[str, str]]
+) -> None:
     """Write ``mappings`` to ``yaml_path`` in YAML format."""
     yaml_path.parent.mkdir(parents=True, exist_ok=True)
     with yaml_path.open("w", encoding="utf-8") as fh:
@@ -268,7 +281,7 @@ def standardize_values(
     gpt_suggest_value: SuggestFunc | None = None,
     file_name: str | None = None,
     log_xlsx: Path | None = None,
-    id_chronogramme: int | None = None,
+    id_chronogramme: str | None = None,
 ) -> pd.Series:
     """Standardize values of one column using dictionary and optional AI."""
 
@@ -293,7 +306,7 @@ def standardize_values(
             method = "ok"
         else:
             prompt_text = (
-                f"Dans le champ \"{col_name}\", comment standardiser la valeur \"{raw}\" ? "
+                f'Dans le champ "{col_name}", comment standardiser la valeur "{raw}" ? '
                 f"Liste autorisee : [{', '.join(allowed)}]"
             )
             safe_val = raw.replace("/", "_").replace(" ", "_")
@@ -338,7 +351,7 @@ def standardize_column_values(
     gpt_suggest_value: SuggestFunc | None = None,
     file_name: str | None = None,
     log_xlsx: Path | None = None,
-    id_chronogramme: int | None = None,
+    id_chronogramme: str | None = None,
 ) -> pd.DataFrame:
     """Standardize values of all columns in *df* using mappings and optional AI."""
 
@@ -364,4 +377,3 @@ def standardize_column_values(
         )
 
     return df
-

--- a/chronogram_pipeline/tests/test_archive_file.py
+++ b/chronogram_pipeline/tests/test_archive_file.py
@@ -11,9 +11,9 @@ def test_archive_file_moves(tmp_path):
     src.write_text("dummy")
     archive_dir = tmp_path / "arc"
 
-    dest = archive_file(src, chrono_id=1, archive_dir=archive_dir)
+    dest = archive_file(src, chrono_id="C001", archive_dir=archive_dir)
 
     assert dest.exists()
     assert dest.parent == archive_dir
     assert not src.exists()
-    assert "1" in dest.stem
+    assert "C001" in dest.stem

--- a/chronogram_pipeline/tests/test_enricher.py
+++ b/chronogram_pipeline/tests/test_enricher.py
@@ -12,7 +12,7 @@ def test_enrich_data_generates_ids(tmp_path):
 
     out = enrich_data(
         df,
-        id_chronogramme=1,
+        id_chronogramme="C001",
         etablissement_nom="CHU",
         etablissement_type="Hopital",
         nom_chronogramme="Test",
@@ -22,7 +22,7 @@ def test_enrich_data_generates_ids(tmp_path):
     assert list(out["numero"]) == [1, 2]
     assert out["id_inject"].tolist() == ["C001_L001", "C001_L002"]
     assert list(out["nb_injects"].unique()) == [2]
-    assert (out["id_chronogramme"] == 1).all()
+    assert (out["id_chronogramme"] == "C001").all()
     assert (out["etablissement_nom"] == "CHU").all()
     assert (out["etablissement_type"] == "Hopital").all()
 
@@ -32,7 +32,7 @@ def test_enrich_data_completes_missing_ids(tmp_path):
 
     out = enrich_data(
         df,
-        id_chronogramme=2,
+        id_chronogramme="C002",
         etablissement_nom="CH",
         etablissement_type="Centre",
         nom_chronogramme="Demo",
@@ -40,7 +40,12 @@ def test_enrich_data_completes_missing_ids(tmp_path):
     )
 
     assert list(out["numero"]) == [1, 2, 3, 4]
-    assert out["id_inject"].tolist() == ["C002_L001", "C002_L002", "C002_L003", "C002_L004"]
+    assert out["id_inject"].tolist() == [
+        "C002_L001",
+        "C002_L002",
+        "C002_L003",
+        "C002_L004",
+    ]
     assert list(out["nb_injects"].unique()) == [4]
 
 
@@ -49,11 +54,10 @@ def test_enrich_data_preserves_input():
     df_copy = df.copy(deep=True)
     enrich_data(
         df,
-        id_chronogramme=3,
+        id_chronogramme="C003",
         etablissement_nom="E",
         etablissement_type="T",
         nom_chronogramme="N",
         date_exercice="2024",
     )
     assert df.equals(df_copy)
-

--- a/chronogram_pipeline/tests/test_form_handler.py
+++ b/chronogram_pipeline/tests/test_form_handler.py
@@ -22,10 +22,7 @@ def test_save_excel_file(tmp_path):
     assert dest.exists()
     assert dest.parent == tmp_path
     assert dest.read_text() == "dummy"
-    assert (
-        dest.name
-        == "Chronogramme_hopital_general_chrono_demo_2024-02-01.xlsx"
-    )
+    assert dest.name == "Chronogramme_hopital_general_chrono_demo_2024-02-01.xlsx"
 
 
 def test_handle_form_submission_saves_and_inserts(tmp_path, monkeypatch):
@@ -60,13 +57,10 @@ def test_handle_form_submission_saves_and_inserts(tmp_path, monkeypatch):
     chrono_id, dest = form_handler.handle_form_submission(form_data.copy())
 
     dest_path = Path(dest)
-    assert isinstance(chrono_id, int)
+    assert isinstance(chrono_id, str)
     assert dest_path.exists()
     assert dest_path.parent == inputs_dir
-    assert (
-        dest_path.name
-        == "Chronogramme_etablissement_demo_plan_a_b_2024-02-01.xlsx"
-    )
+    assert dest_path.name == "Chronogramme_etablissement_demo_plan_a_b_2024-02-01.xlsx"
 
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
@@ -74,4 +68,3 @@ def test_handle_form_submission_saves_and_inserts(tmp_path, monkeypatch):
         ).fetchone()
 
     assert row == (chrono_id, str(dest_path))
-

--- a/chronogram_pipeline/tests/test_injects_insertion.py
+++ b/chronogram_pipeline/tests/test_injects_insertion.py
@@ -26,20 +26,22 @@ def test_insert_injects_and_update_stats(tmp_path):
 
     chrono_id = insert_chronogram_metadata(metadata, db_path=db_path)
 
-    df = pd.DataFrame({
-        "id_inject": [1, 2, 3, 4, 5],
-        "horodatage": ["T0", "T1", "T2", "T3", "T4"],
-        "description": ["a", "b", "c", "d", "e"],
-        "emetteur": ["X"] * 5,
-        "recepteur": ["Y"] * 5,
-        "type_inject": ["Info"] * 5,
-        "modalite": ["Mail"] * 5,
-        "phase_exercice": ["P"] * 5,
-        "observations": [""] * 5,
-        "id_chronogramme": [chrono_id] * 5,
-        "etablissement_nom": [metadata["etablissement_nom"]] * 5,
-        "etablissement_type": [metadata["etablissement_type"]] * 5,
-    })
+    df = pd.DataFrame(
+        {
+            "id_inject": [1, 2, 3, 4, 5],
+            "horodatage": ["T0", "T1", "T2", "T3", "T4"],
+            "description": ["a", "b", "c", "d", "e"],
+            "emetteur": ["X"] * 5,
+            "recepteur": ["Y"] * 5,
+            "type_inject": ["Info"] * 5,
+            "modalite": ["Mail"] * 5,
+            "phase_exercice": ["P"] * 5,
+            "observations": [""] * 5,
+            "id_chronogramme": [chrono_id] * 5,
+            "etablissement_nom": [metadata["etablissement_nom"]] * 5,
+            "etablissement_type": [metadata["etablissement_type"]] * 5,
+        }
+    )
 
     inserted = insert_injects(df, db_path=db_path)
     assert inserted == 5

--- a/chronogram_pipeline/tests/test_metadata_insertion.py
+++ b/chronogram_pipeline/tests/test_metadata_insertion.py
@@ -20,7 +20,7 @@ def test_insert_chronogram_metadata(tmp_path):
         "nb_injects": 5,
     }
     chrono_id = insert_chronogram_metadata(metadata, db_path=db_path)
-    assert isinstance(chrono_id, int)
+    assert isinstance(chrono_id, str)
 
     with sqlite3.connect(db_path) as conn:
         cur = conn.execute(

--- a/chronogram_pipeline/tests/test_persistence_injects.py
+++ b/chronogram_pipeline/tests/test_persistence_injects.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import sqlite3
@@ -31,7 +32,7 @@ def test_insert_two_injects_in_db(tmp_path):
 
     # Prepare DataFrame for DB insertion
     df_db = df_clean.head(2).copy()
-    chrono_id = 99
+    chrono_id = "C099"
     df_db["id_chronogramme"] = chrono_id
     df_db["description"] = df_db["resume"]
     df_db["modalite"] = df_db["nature"]
@@ -47,7 +48,10 @@ def test_insert_two_injects_in_db(tmp_path):
     injects_db = db_dir / "injects.db"
     init_databases(chrono_db, injects_db)
     with sqlite3.connect(injects_db) as conn:
-        conn.execute("INSERT INTO Chronogrammes (id_chronogramme, nom_chronogramme) VALUES (?, ?)", (chrono_id, "Test"))
+        conn.execute(
+            "INSERT INTO Chronogrammes (id_chronogramme, nom_chronogramme) VALUES (?, ?)",
+            (chrono_id, "Test"),
+        )
         conn.commit()
 
     inserted = insert_injects(df_db, db_path=injects_db)
@@ -78,4 +82,3 @@ def test_insert_two_injects_in_db(tmp_path):
             "etablissement_type",
         ]:
             assert row[col] == df_db.iloc[i][col]
-

--- a/chronogram_pipeline/tests/test_standardizer_headers.py
+++ b/chronogram_pipeline/tests/test_standardizer_headers.py
@@ -13,7 +13,9 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
     mapping_csv.write_text("En-tête original,En-tête standard\nDescriptif,Contenu\n")
 
     schema_yaml = tmp_path / "schema.yaml"
-    schema_yaml.write_text("fields:\n  - name: Contenu\n  - name: Recepteur\n  - name: Modalité\n")
+    schema_yaml.write_text(
+        "fields:\n  - name: Contenu\n  - name: Recepteur\n  - name: Modalité\n"
+    )
 
     prompts_dir = tmp_path / "prompts"
 
@@ -34,7 +36,7 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
         gpt_suggest_header=fake_gpt,
         file_name="testfile",
         log_xlsx=log_xlsx,
-        id_chronogramme=10,
+        id_chronogramme="C010",
     )
 
     assert out == ["Contenu", "Recepteur"]
@@ -45,4 +47,4 @@ def test_standardize_headers_uses_dictionary_first(tmp_path):
     # prompt saved
     assert (prompts_dir / "testfile_header_Destinataires.txt").exists()
     log_df = pd.read_excel(log_xlsx)
-    assert set(log_df["id_chronogramme"]) == {10}
+    assert set(log_df["id_chronogramme"]) == {"C010"}

--- a/chronogram_pipeline/tests/test_standardizer_rules.py
+++ b/chronogram_pipeline/tests/test_standardizer_rules.py
@@ -17,7 +17,7 @@ def test_standardize_headers_rules(tmp_path):
     headers = ["Descriptif", "destinataires", "Inconnu"]
 
     out = standardize_headers_rules(
-        headers, mapping_csv=mapping_csv, log_xlsx=log_xlsx, id_chronogramme=42
+        headers, mapping_csv=mapping_csv, log_xlsx=log_xlsx, id_chronogramme="C042"
     )
 
     assert out == ["Contenu", "Recepteur", ""]
@@ -31,5 +31,5 @@ def test_standardize_headers_rules(tmp_path):
         "horodatage",
     ]
     assert df.shape[0] == 3
-    assert set(df["id_chronogramme"]) == {42}
+    assert set(df["id_chronogramme"]) == {"C042"}
     assert (df["methode"] == "règle").all()

--- a/chronogram_pipeline/tests/test_standardizer_values.py
+++ b/chronogram_pipeline/tests/test_standardizer_values.py
@@ -9,7 +9,12 @@ from src.standardizer import standardize_column_values
 
 
 def test_standardize_column_values(tmp_path):
-    df = pd.DataFrame({"type_inject": ["Majeur", "Critique", "Élevé"], "modalite": ["SMS", "Courriel", "SMS"]})
+    df = pd.DataFrame(
+        {
+            "type_inject": ["Majeur", "Critique", "Élevé"],
+            "modalite": ["SMS", "Courriel", "SMS"],
+        }
+    )
 
     value_yaml = tmp_path / "value_mappings.yaml"
     value_yaml.write_text(
@@ -51,7 +56,7 @@ fields:
         gpt_suggest_value=fake_gpt,
         file_name="testfile",
         log_xlsx=log_file,
-        id_chronogramme=5,
+        id_chronogramme="C005",
     )
 
     assert list(out["type_inject"]) == ["Critique", "Critique", "Important"]
@@ -64,5 +69,4 @@ fields:
     assert data["type_inject"]["eleve"] == "Important"
 
     log_df = pd.read_excel(log_file)
-    assert set(log_df["id_chronogramme"]) == {5}
-
+    assert set(log_df["id_chronogramme"]) == {"C005"}

--- a/docs/kpi_monitoring.md
+++ b/docs/kpi_monitoring.md
@@ -17,7 +17,7 @@ Soit `N` le nombre total d'éléments considérés pour un traitement (en‑têt
   où `N_{vide}` est le nombre d'éléments n'ayant reçu aucune correspondance.
 - **Complétude des injects** :
   \[\text{completude} = \frac{\text{nombre de cellules renseignées}}{\text{nombre total de cellules attendues}}\]
-  Le calcul exclut les colonnes techniques `id_inject_global` et `id_chronogramme`.
+  Le calcul exclut la colonne technique `id_chronogramme`.
 
 ## Seuils d'alerte
 

--- a/scripts/monitor_kpi.py
+++ b/scripts/monitor_kpi.py
@@ -29,7 +29,7 @@ def _load_chrono_id(log_file: Path) -> int | None:
     return None
 
 
-def _compute_completeness(conn: sqlite3.Connection, chrono_id: int) -> float:
+def _compute_completeness(conn: sqlite3.Connection, chrono_id: str) -> float:
     df = pd.read_sql(
         "SELECT * FROM Injects WHERE id_chronogramme = ?",
         conn,
@@ -37,7 +37,7 @@ def _compute_completeness(conn: sqlite3.Connection, chrono_id: int) -> float:
     )
     if df.empty:
         return 0.0
-    cols = [c for c in df.columns if c not in {"id_inject_global", "id_chronogramme"}]
+    cols = [c for c in df.columns if c not in {"id_chronogramme"}]
     filled = df[cols].notna().sum().sum()
     total = len(df) * len(cols)
     return float(filled) / float(total) if total else 0.0
@@ -59,7 +59,10 @@ def generate_report() -> None:
             total = len(subset)
             auto_count = (subset["methode"] == "règle").sum()
             ia_count = (subset["methode"] == "IA").sum()
-            unresolved = subset["champ_standard"].isna().sum() + (subset["champ_standard"] == "").sum()
+            unresolved = (
+                subset["champ_standard"].isna().sum()
+                + (subset["champ_standard"] == "").sum()
+            )
             auto_rate = auto_count / total if total else 0.0
             ia_rate = ia_count / total if total else 0.0
             unresolved_rate = unresolved / total if total else 0.0

--- a/tests/test_db_completion.py
+++ b/tests/test_db_completion.py
@@ -47,9 +47,7 @@ def test_chronogram_completion(tmp_path):
     insert_chronogram_metadata(metadata, db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:
-        _, failures = _completion_for_table(
-            conn, "Chronogrammes", {"id_chronogramme"}
-        )
+        _, failures = _completion_for_table(conn, "Chronogrammes", {"id_chronogramme"})
     assert not failures, f"Incomplete chronogram rows: {failures}"
 
 
@@ -88,6 +86,6 @@ def test_injects_completion(tmp_path):
         _, failures = _completion_for_table(
             conn,
             "Injects",
-            {"id_inject_global", "id_chronogramme", "id_inject"},
+            {"id_chronogramme", "id_inject"},
         )
     assert not failures, f"Incomplete inject rows: {failures}"


### PR DESCRIPTION
## Summary
- switch chronogram primary key to text `C###`
- generate chrono IDs sequentially when inserting metadata
- drop the `id_inject_global` column from Injects
- adapt completeness script and documentation
- update unit tests for new ID format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc8d2f52883279a1adc5ca5e504e9